### PR TITLE
Feat: Diary 컨트롤러에 API 기능별 swagger 엔드포인트 명세

### DIFF
--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -61,12 +61,28 @@ public class DiaryController {
     @DeleteMapping("/{diaryId}")
     @Operation(
             summary = "글 삭제 API"
-            , description = "글을 삭제합니다. Param으로 memberId를 입력하세요"
+            , description = "글을 삭제합니다. Param으로 diaryId를 입력하세요"
             //, security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<DiaryResponseDTO> deleteDiary(
     ){
         return null;
     }
+
+
+
+    // 글 공개/비공개 설정
+    @PatchMapping("/{diaryId}/visibility")
+    @Operation(
+            summary = "글 공개/비공개 API"
+            , description = "글의 공개/비공개 유무를 설정합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> setDiaryVisibility(
+    ){
+        return null;
+    }
+
+
 
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -1,4 +1,72 @@
 package com.codiary.backend.global.web.controller;
 
+import com.codiary.backend.global.apiPayload.ApiResponse;
+import com.codiary.backend.global.service.DiaryService.DiaryCommandService;
+import com.codiary.backend.global.service.DiaryService.DiaryQueryService;
+import com.codiary.backend.global.web.dto.Diary.DiaryResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@CrossOrigin
+@RequestMapping("/diaries")
+@Slf4j
 public class DiaryController {
+    //private final DiaryCommandService diaryCommandService;
+    //private final DiaryQueryService diaryQueryService;
+
+    // 글 생성하기
+    @PostMapping()
+    @Operation(
+            summary = "글 생성 API"
+            , description = "글을 생성합니다."
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> createDiary(
+    ){
+        return null;
+    }
+
+    // 글 상세 조회
+    @GetMapping("/{diaryId}")
+    @Operation(
+            summary = "글 상세 조회 API"
+            , description = "글을 상세 조회합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> findDiary(
+    ){
+        return null;
+    }
+
+    // 글 수정하기
+    @PatchMapping("/{diaryId}")
+    @Operation(
+            summary = "글 수정 API"
+            , description = "글을 수정합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> updateDiary(
+    ){
+        return null;
+    }
+
+    // 글 삭제하기
+    @DeleteMapping("/{diaryId}")
+    @Operation(
+            summary = "글 삭제 API"
+            , description = "글을 삭제합니다. Param으로 memberId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> deleteDiary(
+    ){
+        return null;
+    }
+
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -83,6 +83,16 @@ public class DiaryController {
         return null;
     }
 
-
+    // 글 커스터마이징 옵션 변경
+    @PatchMapping("/{diaryId}/customize")
+    @Operation(
+            summary = "글 커스터마이징 옵션 변경 API"
+            , description = "글의 커스터마이징 옵션을 변경합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> customizeDiary(
+    ){
+        return null;
+    }
 
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -95,4 +95,17 @@ public class DiaryController {
         return null;
     }
 
+    // 글 공동 저자 설정
+    @PatchMapping("/{diaryId}/coauthors")
+    @Operation(
+            summary = "글 공동 저자 설정 API"
+            , description = "글의 공동 저자를 설정합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> setDiaryCoauthor(
+    ){
+        return null;
+    }
+
+
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -131,6 +131,16 @@ public class DiaryController {
         return null;
     }
 
-
+    // AI로 코드 실행 미리보기
+    @GetMapping("/{diaryId}/code-preview")
+    @Operation(
+            summary = "AI로 코드 실행 미리보기 API"
+            , description = "AI로 특정 글에 포함된 코드를 실행하여 미리보기 결과를 반환합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> showDiaryCodePreview(
+    ){
+        return null;
+    }
 
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -118,4 +118,19 @@ public class DiaryController {
     ){
         return null;
     }
+
+    // 글의 카테고리 및 키워드 설정
+    @PatchMapping("/{diaryId}/categories")
+    @Operation(
+            summary = "글의 카테고리 및 키워드 설정 API"
+            , description = "글의 카테고리 및 키워드를 설정합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> setDiaryCategory(
+    ){
+        return null;
+    }
+
+
+
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/DiaryController.java
@@ -107,5 +107,15 @@ public class DiaryController {
         return null;
     }
 
-
+    // 글의 소속 팀 설정
+    @PatchMapping("/{diaryId}/team")
+    @Operation(
+            summary = "글의 소속 팀 설정 API"
+            , description = "글의 소속 팀을 설정합니다. Param으로 diaryId를 입력하세요"
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<DiaryResponseDTO> setDiaryTeam(
+    ){
+        return null;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #6

## 📝작업 내용
> Diary 컨트롤러에 API 기능별 swagger 엔드포인트 명세

## 🔎코드 설명 및 참고 사항
> - 글 작성/조회/수정/삭제 CRUD 기능 API 및 기타 관련 API swagger 엔드포인트 명세
>- 기타 API: 글 공개/비공개 설정, 글 커스터마이징 옵션 설정, 공동 저자 설정, 소속 팀 설정, 카테고리 및 키워드 설정, AI로 코드 미리보기 

## 💬리뷰 요구사항
