### PR TITLE
Feat: 팔로우 관련 기능 구현

### DIFF
--- a/src/main/java/com/codiary/backend/BackendApplication.java
+++ b/src/main/java/com/codiary/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.codiary.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_ID_NULL(HttpStatus.BAD_REQUEST, "MEMBER_1004", "사용자 아이디는 필수 입니다."),
     MEMBER_ADMIN_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "MEMBER_1005", "관리자 권한이 없습니다."),
 
+    MEMBER_SELF_FOLLOW(HttpStatus.BAD_REQUEST, "MEMBER_1100", "셀프 팔로우 기능은 제공하지 않습니다"),
+
     // 팀 관련 에러 2000
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TEAM_2001", "팀이 없습니다."),
     TEAM_NAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "TEAM_2002", "팀 이름입력은 필수 입니다."),

--- a/src/main/java/com/codiary/backend/global/converter/MemberConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/MemberConverter.java
@@ -1,14 +1,13 @@
 package com.codiary.backend.global.converter;
 
 import com.codiary.backend.global.domain.entity.Follow;
-import com.codiary.backend.global.service.MemberService.FollowService;
+import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import com.codiary.backend.global.web.dto.Member.MemberSumResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberConverter {
-
-    public static FollowResponseDto followResponseDto;
 
     public FollowResponseDto toManageFollowDto(Follow follow) {
         return FollowResponseDto.builder()
@@ -18,6 +17,14 @@ public class MemberConverter {
                 .followingId(follow.getToMember().getMemberId())
                 .followingName(follow.getToMember().getNickname())
                 .followStatus(follow.getFollowStatus())
+                .build();
+    }
+
+    public MemberSumResponseDto toFollowResponseDto(Member member) {
+        return MemberSumResponseDto.builder()
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
+                .photoUrl(member.getPhotoUrl())
                 .build();
     }
 }

--- a/src/main/java/com/codiary/backend/global/converter/MemberConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/MemberConverter.java
@@ -1,4 +1,23 @@
 package com.codiary.backend.global.converter;
 
+import com.codiary.backend.global.domain.entity.Follow;
+import com.codiary.backend.global.service.MemberService.FollowService;
+import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberConverter {
+
+    public static FollowResponseDto followResponseDto;
+
+    public FollowResponseDto toManageFollowDto(Follow follow) {
+        return FollowResponseDto.builder()
+                .followId(follow.getFollowId())
+                .followerId(follow.getFromMember().getMemberId())
+                .followerName(follow.getFromMember().getNickname())
+                .followingId(follow.getToMember().getMemberId())
+                .followingName(follow.getToMember().getNickname())
+                .followStatus(follow.getFollowStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/codiary/backend/global/domain/common/BaseEntity.java
+++ b/src/main/java/com/codiary/backend/global/domain/common/BaseEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 public abstract class BaseEntity {
     @CreatedDate
-    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP")
+    @Column(name = "created_at", updatable = false,  nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/com/codiary/backend/global/domain/entity/Follow.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Follow.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Follow {
+public class Follow extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "follow_id", nullable = false, columnDefinition = "bigint")

--- a/src/main/java/com/codiary/backend/global/domain/entity/Follow.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Follow.java
@@ -1,0 +1,46 @@
+package com.codiary.backend.global.domain.entity;
+
+import com.codiary.backend.global.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id", nullable = false, columnDefinition = "bigint")
+    private Long followId;
+
+    @ManyToOne
+    @JoinColumn(name = "from_member")
+    private Member fromMember;
+
+    @ManyToOne
+    @JoinColumn(name = "to_member")
+    private Member toMember;
+
+    @Column(name="follow_status", columnDefinition = "tinyint")
+    private Boolean followStatus;
+
+
+    @Builder
+    public Follow(Long followId, Member fromMember, Member toMember, Boolean followStatus) {
+        this.followId = followId;
+        this.fromMember = fromMember;
+        this.toMember = toMember;
+        this.followStatus = followStatus;
+    }
+
+    @Builder
+    public Follow(Member fromMember, Member toMember, Boolean followStatus) {
+        this.fromMember = fromMember;
+        this.toMember = toMember;
+        this.followStatus = followStatus;
+    }
+}

--- a/src/main/java/com/codiary/backend/global/domain/entity/Member.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Member.java
@@ -73,4 +73,9 @@ public class Member extends BaseEntity {
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> commentList = new ArrayList<>();
 
+  @OneToMany(mappedBy = "fromMember", fetch = FetchType.LAZY)
+  private List<Follow> followings = new ArrayList<>();
+
+  @OneToMany(mappedBy = "toMember", fetch = FetchType.LAZY)
+  private List<Follow> followers = new ArrayList<>();
 }

--- a/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package com.codiary.backend.global.repository;
+
+import com.codiary.backend.global.domain.entity.Follow;
+import com.codiary.backend.global.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
+}

--- a/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
@@ -4,8 +4,13 @@ import com.codiary.backend.global.domain.entity.Follow;
 import com.codiary.backend.global.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
+
+    List<Follow> findByFromMemberAndFollowStatus(Member member, boolean status);
+
+    List<Follow> findByToMemberAndFollowStatus(Member member, boolean status);
 }

--- a/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/FollowRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
 
-    List<Follow> findByFromMemberAndFollowStatus(Member member, boolean status);
+    List<Follow> findByFromMemberAndFollowStatusTrueOrderByUpdatedAt(Member member);
 
-    List<Follow> findByToMemberAndFollowStatus(Member member, boolean status);
+    List<Follow> findByToMemberAndFollowStatusTrueOrderByUpdatedAt(Member member);
 }

--- a/src/main/java/com/codiary/backend/global/repository/MemberRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package com.codiary.backend.global.repository;
 
-public interface MemberRepository {
+import com.codiary.backend.global.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
+++ b/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
@@ -62,4 +62,21 @@ public class FollowService {
 
         return memberConverter.toManageFollowDto(follow);
     }
+
+    @Transactional
+    public Boolean isFollowing(Long toId, Long fromId) {
+        if (toId.equals(fromId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_SELF_FOLLOW);
+        }
+
+        Member fromMember = memberRepository.findById(fromId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member toMember = memberRepository.findById(toId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return followRepository.findByFromMemberAndToMember(fromMember, toMember)
+                .map(Follow::getFollowStatus)
+                .orElse(false);
+
+    }
 }

--- a/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
+++ b/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
@@ -8,9 +8,13 @@ import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.repository.FollowRepository;
 import com.codiary.backend.global.repository.MemberRepository;
 import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import com.codiary.backend.global.web.dto.Member.MemberSumResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -77,6 +81,29 @@ public class FollowService {
         return followRepository.findByFromMemberAndToMember(fromMember, toMember)
                 .map(Follow::getFollowStatus)
                 .orElse(false);
+    }
 
+    @Transactional
+    public List<MemberSumResponseDto> getFollowings(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Follow> followings = followRepository.findByFromMemberAndFollowStatus(member, true);
+
+        return followings.stream()
+                .map(follow -> memberConverter.toFollowResponseDto(follow.getToMember()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<MemberSumResponseDto> getFollowers(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Follow> followings = followRepository.findByToMemberAndFollowStatus(member, true);
+
+        return followings.stream()
+                .map(follow -> memberConverter.toFollowResponseDto(follow.getFromMember()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
+++ b/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
@@ -1,0 +1,65 @@
+package com.codiary.backend.global.service.MemberService;
+
+import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
+import com.codiary.backend.global.apiPayload.exception.GeneralException;
+import com.codiary.backend.global.converter.MemberConverter;
+import com.codiary.backend.global.domain.entity.Follow;
+import com.codiary.backend.global.domain.entity.Member;
+import com.codiary.backend.global.repository.FollowRepository;
+import com.codiary.backend.global.repository.MemberRepository;
+import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+    private final MemberConverter memberConverter;
+
+    @Transactional
+    public FollowResponseDto follow(Long toId, Long fromId) {
+        if (toId.equals(fromId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_SELF_FOLLOW);
+        }
+
+        Member fromMember = memberRepository.findById(fromId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member toMember = memberRepository.findById(toId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Follow follow = followRepository.findByFromMemberAndToMember(fromMember, toMember)
+                .orElse(null);
+
+        if (follow == null) {
+            follow = Follow.builder()
+                    .fromMember(fromMember)
+                    .toMember(toMember)
+                    .followStatus(true)
+                    .build();
+            fromMember.getFollowings().add(follow);
+            toMember.getFollowers().add(follow);
+        } else {
+            follow = Follow.builder()
+                    .followId(follow.getFollowId())
+                    .fromMember(follow.getFromMember())
+                    .toMember(follow.getToMember())
+                    .followStatus(!follow.getFollowStatus())
+                    .build();
+            if (!follow.getFollowStatus()) {
+                fromMember.getFollowings().add(follow);
+                toMember.getFollowers().add(follow);
+            } else {
+                fromMember.getFollowings().remove(follow);
+                toMember.getFollowers().remove(follow);
+            }
+        }
+        followRepository.save(follow);
+        memberRepository.save(fromMember);
+        memberRepository.save(toMember);
+
+        return memberConverter.toManageFollowDto(follow);
+    }
+}

--- a/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
+++ b/src/main/java/com/codiary/backend/global/service/MemberService/FollowService.java
@@ -88,7 +88,7 @@ public class FollowService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        List<Follow> followings = followRepository.findByFromMemberAndFollowStatus(member, true);
+        List<Follow> followings = followRepository.findByFromMemberAndFollowStatusTrueOrderByUpdatedAt(member);
 
         return followings.stream()
                 .map(follow -> memberConverter.toFollowResponseDto(follow.getToMember()))
@@ -100,7 +100,7 @@ public class FollowService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        List<Follow> followings = followRepository.findByToMemberAndFollowStatus(member, true);
+        List<Follow> followings = followRepository.findByToMemberAndFollowStatusTrueOrderByUpdatedAt(member);
 
         return followings.stream()
                 .map(follow -> memberConverter.toFollowResponseDto(follow.getFromMember()))

--- a/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
@@ -5,10 +5,7 @@ import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
 import com.codiary.backend.global.service.MemberService.FollowService;
 import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members")
@@ -24,6 +21,11 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.follow(toId, fromId));
     }
 
-
+    //TODO: 로그인 구현 완료 시 principal 추가(follow 주체) 필요
+    @GetMapping("/follow/{id}")
+    public ApiResponse<Boolean> isFollowing(@PathVariable("id") Long toId) {
+        Long fromId = 1L;
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.isFollowing(toId, fromId));
+    }
 
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
@@ -4,8 +4,11 @@ import com.codiary.backend.global.apiPayload.ApiResponse;
 import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
 import com.codiary.backend.global.service.MemberService.FollowService;
 import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import com.codiary.backend.global.web.dto.Member.MemberSumResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/members")
@@ -28,4 +31,17 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.isFollowing(toId, fromId));
     }
 
+    //TODO: 로그인 구현 완료 시 principal 추가(follow 주체) 필요
+    @GetMapping("/following")
+    public ApiResponse<List<MemberSumResponseDto>> getFollowings() {
+        Long id = 1L;
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.getFollowings(id));
+    }
+
+    //TODO: 로그인 구현 완료 시 principal 추가(follow 주체) 필요
+    @GetMapping("/follower")
+    public ApiResponse<List<MemberSumResponseDto>> getFollowers() {
+        Long id = 3L;
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.getFollowers(id));
+    }
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/MemberController.java
@@ -1,4 +1,29 @@
 package com.codiary.backend.global.web.controller;
 
+import com.codiary.backend.global.apiPayload.ApiResponse;
+import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
+import com.codiary.backend.global.service.MemberService.FollowService;
+import com.codiary.backend.global.web.dto.Member.FollowResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
 public class MemberController {
+
+    private final FollowService followService;
+
+    //TODO: 로그인 구현 완료 시 principal 추가(follow 주체) 필요
+    @PostMapping("/follow/{id}")
+    public ApiResponse<FollowResponseDto> follow(@PathVariable("id") Long toId) {
+        Long fromId = 1L;
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, followService.follow(toId, fromId));
+    }
+
+
+
 }

--- a/src/main/java/com/codiary/backend/global/web/dto/Member/FollowResponseDto.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Member/FollowResponseDto.java
@@ -1,6 +1,5 @@
 package com.codiary.backend.global.web.dto.Member;
 
-import com.codiary.backend.global.domain.entity.Follow;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/codiary/backend/global/web/dto/Member/FollowResponseDto.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Member/FollowResponseDto.java
@@ -1,0 +1,15 @@
+package com.codiary.backend.global.web.dto.Member;
+
+import com.codiary.backend.global.domain.entity.Follow;
+import lombok.Builder;
+
+@Builder
+public record FollowResponseDto(
+        Long followId,
+        Long followerId,
+        String followerName,
+        Long followingId,
+        String followingName,
+        Boolean followStatus
+) {
+}

--- a/src/main/java/com/codiary/backend/global/web/dto/Member/MemberSumResponseDto.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Member/MemberSumResponseDto.java
@@ -1,0 +1,11 @@
+package com.codiary.backend.global.web.dto.Member;
+
+import lombok.Builder;
+
+@Builder
+public record MemberSumResponseDto(
+        Long memberId,
+        String nickname,
+        String photoUrl
+) {
+}

--- a/src/test/java/com/codiary/backend/BackendApplicationTests.java
+++ b/src/test/java/com/codiary/backend/BackendApplicationTests.java
@@ -2,7 +2,9 @@ package com.codiary.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootTest
 class BackendApplicationTests {
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

#17 

## 📝작업 내용
- 팔로우 기능 + 취소 기능 
- 팔로우 조회 기능
- 팔로잉 목록 조회
- 팔로워 목록 조회

## 🔎코드 설명 및 참고 사항
- 팔로잉/팔로워 목록 조회는 우선 update된 순으로 정렬해두었습니다.
- controller에서 user id는 임의로 설정해두었고, 로그인 구현 완료시 연결 예정입니다.
- 스웨거 description은 추후에 한꺼번에 적용해두겠습니다!
- BaseEntity와의 연동을 위해 Application file에 `@EnableJpaAuditing` 설정해두었습니다~
- Follow Service는 굳이 인터페이스+구현체로 나누지 않아도 될 것 같아 클래스 하나로 만들어두었습니다. 

## 💬리뷰 요구사항
>
