### PR TITLE
Feat: 다이어리 조회 관련 API에서 결과 리스트를 페이징으로 조회하도록 구현 및 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -39,7 +39,8 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_UPDATE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3002", "포스트 수정 권한이 없습니다."),
     POST_DELETE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3003", "포스트 삭제 권한이 없습니다."),
     POST_ADD_MEMBER_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3004", "포스트에 사용자를 추가할 권한이 없습니다."),
-    POST_MEMBER_DELETE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3005", "포스트 참여자 삭제 권한이 없습니다.");
+    POST_MEMBER_DELETE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3005", "포스트 참여자 삭제 권한이 없습니다."),
+    POST_NOT_EXIST_BY_TEAM(HttpStatus.BAD_REQUEST, "POST_3006", "해당 팀의 다이어리 목록이 없습니다.");
 
     // 코멘트 관련 에러 4000
 

--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -40,8 +40,9 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_DELETE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3003", "포스트 삭제 권한이 없습니다."),
     POST_ADD_MEMBER_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3004", "포스트에 사용자를 추가할 권한이 없습니다."),
     POST_MEMBER_DELETE_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3005", "포스트 참여자 삭제 권한이 없습니다."),
-    POST_NOT_EXIST_BY_TEAM(HttpStatus.BAD_REQUEST, "POST_3006", "해당 팀의 다이어리 목록이 없습니다.");
-
+    POST_NOT_EXIST_BY_TEAM(HttpStatus.BAD_REQUEST, "POST_3006", "해당 팀의 다이어리 목록이 없습니다."),
+    POST_NOT_EXIST_BY_PROJECT(HttpStatus.BAD_REQUEST, "POST_3007", "해당 프로젝트의 다이어리 목록이 없습니다."),
+    POST_NOT_EXIST_BY_MEMBER(HttpStatus.BAD_REQUEST, "POST_3008", "해당 멤버의 다이어리 목록이 없습니다.");
     // 코멘트 관련 에러 4000
 
 

--- a/src/main/java/com/codiary/backend/global/apiPayload/exception/handler/PostHandler.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/exception/handler/PostHandler.java
@@ -1,0 +1,11 @@
+package com.codiary.backend.global.apiPayload.exception.handler;
+
+import com.codiary.backend.global.apiPayload.code.BaseErrorCode;
+import com.codiary.backend.global.apiPayload.exception.GeneralException;
+
+public class PostHandler extends GeneralException {
+
+    public PostHandler(BaseErrorCode baseErrorCode){
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -33,6 +33,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postAccess(post.getPostAccess())
                 .build();
     }
 
@@ -47,6 +48,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postAccess(post.getPostAccess())
                 .build();
     }
 
@@ -62,6 +64,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -89,6 +92,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -114,6 +118,7 @@ public class PostConverter {
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -136,7 +141,7 @@ public class PostConverter {
     }
 
 
-    //
+    // 프로젝트별 저자의 Post 조회
     public static PostResponseDTO.MemberPostInProjectPreviewDTO toMemberPostInProjectPreviewDTO(Post post) {
         return PostResponseDTO.MemberPostInProjectPreviewDTO.builder()
                 .projectId(post.getProject().getProjectId())
@@ -149,12 +154,13 @@ public class PostConverter {
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
-    //
+    // 프로젝트별 저자의 Post 페이징 조회
     public static PostResponseDTO.MemberPostInProjectPreviewListDTO toMemberPostInProjectPreviewListDTO(Page<Post> posts) {
         List<PostResponseDTO.MemberPostInProjectPreviewDTO> memberPostInProjectPreviewListDTO = posts.getContent().stream()
                 .map(PostConverter::toMemberPostInProjectPreviewDTO)
@@ -162,6 +168,41 @@ public class PostConverter {
 
         return PostResponseDTO.MemberPostInProjectPreviewListDTO.builder()
                 .posts(memberPostInProjectPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+    // 프로젝트별 팀의 Post 조회
+    public static PostResponseDTO.TeamPostInProjectPreviewDTO toTeamPostInProjectPreviewDTO(Post post) {
+        return PostResponseDTO.TeamPostInProjectPreviewDTO.builder()
+                .projectId(post.getProject().getProjectId())
+                .teamId(post.getTeam().getTeamId())
+                .postId(post.getPostId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postTitle(post.getPostTitle())
+                .postStatus(post.getPostStatus())
+                .postCategory(post.getPostCategory())
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 프로젝트별 팀의 Post 페이징 조회
+    public static PostResponseDTO.TeamPostInProjectPreviewListDTO toTeamPostInProjectPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.TeamPostInProjectPreviewDTO> teamPostInProjectPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toTeamPostInProjectPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.TeamPostInProjectPreviewListDTO.builder()
+                .posts(teamPostInProjectPreviewListDTO)
                 .listSize(posts.getNumberOfElements())
                 .totalPage(posts.getTotalPages())
                 .totalElements(posts.getTotalElements())

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -76,12 +76,18 @@ public class PostConverter {
     }
 
     // Post 전체 리스트 조회
-    public static PostResponseDTO.PostPreviewListDTO toPostPreviewListDTO(List<Post> postList) {
-        List<PostResponseDTO.PostPreviewDTO> postPreviewDTOList = IntStream.range(0, postList.size())
-                .mapToObj(i -> toPostPreviewDTO(postList.get(i)))
+    public static PostResponseDTO.PostPreviewListDTO toPostPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.PostPreviewDTO> PostPreviewDTOList = posts.getContent().stream()
+                .map(PostConverter::toPostPreviewDTO)
                 .collect(Collectors.toList());
+
         return PostResponseDTO.PostPreviewListDTO.builder()
-                .posts(postPreviewDTOList)
+                .posts(PostPreviewDTOList)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
                 .build();
     }
 

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -95,11 +95,11 @@ public class PostConverter {
     }
     // 저자별 Post 리스트 조회
     public static PostResponseDTO.MemberPostResultListDTO toMemberPostResultListDTO(List<Post> memberPostList) {
-        List<PostResponseDTO.MemberPostResultDTO> memberPostResultDTOList = IntStream.range(0, memberPostList.size())
+        List<PostResponseDTO.MemberPostResultDTO> memberPostResultListDTO = IntStream.range(0, memberPostList.size())
                 .mapToObj(i -> toMemberPostResultDTO(memberPostList.get(i)))
                 .collect(Collectors.toList());
         return PostResponseDTO.MemberPostResultListDTO.builder()
-                .posts(memberPostResultDTOList)
+                .posts(memberPostResultListDTO)
                 .build();
     }
 
@@ -120,13 +120,13 @@ public class PostConverter {
     }
 
     // 팀별 Post 페이징 조회
-    public static PostResponseDTO.TeamPostPreviewListDTO toTeamPostPreviewDTOList(Page<Post> posts) {
-        List<PostResponseDTO.TeamPostPreviewDTO> teamPostResultDTOList = posts.getContent().stream()
+    public static PostResponseDTO.TeamPostPreviewListDTO toTeamPostPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.TeamPostPreviewDTO> teamPostPreviewDTOList = posts.getContent().stream()
                 .map(PostConverter::toTeamPostPreviewDTO)
                 .collect(Collectors.toList());
 
         return PostResponseDTO.TeamPostPreviewListDTO.builder()
-                .posts(teamPostResultDTOList)
+                .posts(teamPostPreviewDTOList)
                 .listSize(posts.getNumberOfElements())
                 .totalPage(posts.getTotalPages())
                 .totalElements(posts.getTotalElements())
@@ -136,5 +136,38 @@ public class PostConverter {
     }
 
 
+    //
+    public static PostResponseDTO.MemberPostInProjectPreviewDTO toMemberPostInProjectPreviewDTO(Post post) {
+        return PostResponseDTO.MemberPostInProjectPreviewDTO.builder()
+                .projectId(post.getProject().getProjectId())
+                .memberId(post.getMember().getMemberId())
+                .postId(post.getPostId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postTitle(post.getPostTitle())
+                .postStatus(post.getPostStatus())
+                .postCategory(post.getPostCategory())
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    //
+    public static PostResponseDTO.MemberPostInProjectPreviewListDTO toMemberPostInProjectPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.MemberPostInProjectPreviewDTO> memberPostInProjectPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toMemberPostInProjectPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInProjectPreviewListDTO.builder()
+                .posts(memberPostInProjectPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
 
 }

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -4,6 +4,7 @@ import com.codiary.backend.global.domain.entity.Post;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
 import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,6 +50,7 @@ public class PostConverter {
                 .build();
     }
 
+    // Post 조회
     public static PostResponseDTO.PostPreviewDTO toPostPreviewDTO(Post post) {
         return PostResponseDTO.PostPreviewDTO.builder()
                 .postId(post.getPostId())
@@ -65,6 +67,7 @@ public class PostConverter {
                 .build();
     }
 
+    // Post 전체 리스트 조회
     public static PostResponseDTO.PostPreviewListDTO toPostPreviewListDTO(List<Post> postList) {
         List<PostResponseDTO.PostPreviewDTO> postPreviewDTOList = IntStream.range(0, postList.size())
                 .mapToObj(i -> toPostPreviewDTO(postList.get(i)))
@@ -74,8 +77,10 @@ public class PostConverter {
                 .build();
     }
 
+    // 저자별 Post 조회
     public static PostResponseDTO.MemberPostResultDTO toMemberPostResultDTO(Post post) {
         return PostResponseDTO.MemberPostResultDTO.builder()
+                .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
                 .postTitle(post.getPostTitle())
                 .postStatus(post.getPostStatus())
@@ -88,7 +93,7 @@ public class PostConverter {
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
-
+    // 저자별 Post 리스트 조회
     public static PostResponseDTO.MemberPostResultListDTO toMemberPostResultListDTO(List<Post> memberPostList) {
         List<PostResponseDTO.MemberPostResultDTO> memberPostResultDTOList = IntStream.range(0, memberPostList.size())
                 .mapToObj(i -> toMemberPostResultDTO(memberPostList.get(i)))
@@ -97,4 +102,39 @@ public class PostConverter {
                 .posts(memberPostResultDTOList)
                 .build();
     }
+
+    // 팀별 Post 조회
+    public static PostResponseDTO.TeamPostPreviewDTO toTeamPostPreviewDTO(Post post) {
+        return PostResponseDTO.TeamPostPreviewDTO.builder()
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postId(post.getPostId())
+                .postTitle(post.getPostTitle())
+                .postStatus(post.getPostStatus())
+                .postCategory(post.getPostCategory())
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 팀별 Post 페이징 조회
+    public static PostResponseDTO.TeamPostPreviewListDTO toTeamPostPreviewDTOList(Page<Post> posts) {
+        List<PostResponseDTO.TeamPostPreviewDTO> teamPostResultDTOList = posts.getContent().stream()
+                .map(PostConverter::toTeamPostPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.TeamPostPreviewListDTO.builder()
+                .posts(teamPostResultDTOList)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+
+
 }

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -25,6 +25,9 @@ public class PostConverter {
     public static PostResponseDTO.CreatePostResultDTO toCreateResultDTO(Post post) {
         return PostResponseDTO.CreatePostResultDTO.builder()
                 .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject().getProjectId())
                 .postTitle(post.getPostTitle())
                 //.postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
@@ -32,7 +35,6 @@ public class PostConverter {
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
-                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postAccess(post.getPostAccess())
                 .build();
     }
@@ -40,6 +42,9 @@ public class PostConverter {
     public static PostResponseDTO.UpdatePostResultDTO toUpdatePostResultDTO(Post post) {
         return PostResponseDTO.UpdatePostResultDTO.builder()
                 .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject().getProjectId())
                 .postTitle(post.getPostTitle())
                 //.postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
@@ -47,7 +52,6 @@ public class PostConverter {
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
-                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postAccess(post.getPostAccess())
                 .build();
     }
@@ -57,13 +61,14 @@ public class PostConverter {
         return PostResponseDTO.PostPreviewDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject().getProjectId())
                 .postTitle(post.getPostTitle())
                 .postStatus(post.getPostStatus())
                 .postCategory(post.getPostCategory())
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
-                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
@@ -81,29 +86,36 @@ public class PostConverter {
     }
 
     // 저자별 Post 조회
-    public static PostResponseDTO.MemberPostResultDTO toMemberPostResultDTO(Post post) {
-        return PostResponseDTO.MemberPostResultDTO.builder()
+    public static PostResponseDTO.MemberPostPreviewDTO toMemberPostPreviewDTO(Post post) {
+        return PostResponseDTO.MemberPostPreviewDTO.builder()
                 .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject().getProjectId())
                 .postTitle(post.getPostTitle())
                 .postStatus(post.getPostStatus())
                 .postCategory(post.getPostCategory())
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
-                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postAccess(post.getPostAccess())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
-    // 저자별 Post 리스트 조회
-    public static PostResponseDTO.MemberPostResultListDTO toMemberPostResultListDTO(List<Post> memberPostList) {
-        List<PostResponseDTO.MemberPostResultDTO> memberPostResultListDTO = IntStream.range(0, memberPostList.size())
-                .mapToObj(i -> toMemberPostResultDTO(memberPostList.get(i)))
+    // 저자별 Post 페이징 조회
+    public static PostResponseDTO.MemberPostPreviewListDTO toMemberPostPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.MemberPostPreviewDTO> memberPostPreviewDTOList = posts.getContent().stream()
+                .map(PostConverter::toMemberPostPreviewDTO)
                 .collect(Collectors.toList());
-        return PostResponseDTO.MemberPostResultListDTO.builder()
-                .posts(memberPostResultListDTO)
+
+        return PostResponseDTO.MemberPostPreviewListDTO.builder()
+                .posts(memberPostPreviewDTOList)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
                 .build();
     }
 
@@ -112,6 +124,8 @@ public class PostConverter {
         return PostResponseDTO.TeamPostPreviewDTO.builder()
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .projectId(post.getProject().getProjectId())
                 .postTitle(post.getPostTitle())
                 .postStatus(post.getPostStatus())
                 .postCategory(post.getPostCategory())

--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -211,4 +211,39 @@ public class PostConverter {
                 .build();
     }
 
+    // 팀별 멤버의 Post 조회
+    public static PostResponseDTO.MemberPostInTeamPreviewDTO toMemberPostInTeamPreviewDTO(Post post) {
+        return PostResponseDTO.MemberPostInTeamPreviewDTO.builder()
+                .teamId(post.getTeam().getTeamId())
+                .memberId(post.getMember().getMemberId())
+                .postId(post.getPostId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postTitle(post.getPostTitle())
+                .postStatus(post.getPostStatus())
+                .postCategory(post.getPostCategory())
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 팀별 멤버의 Post 페이징 조회
+    public static PostResponseDTO.MemberPostInTeamPreviewListDTO toMemberPostInTeamPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.MemberPostInTeamPreviewDTO> memberPostInTeamPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toMemberPostInTeamPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInTeamPreviewListDTO.builder()
+                .posts(memberPostInTeamPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
 }

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -20,6 +20,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
     Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
     Page<Post> findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(Project project, Team team, Pageable pageable);
+    Page<Post> findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(Team team, Member member, Pageable pageable);
     boolean existsByTeam(Team team);
     boolean existsByProject(Project project);
     boolean existsByMember(Member member);

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle);
-    List<Post> findAllByOrderByCreatedAtDesc();
+    Page<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle, Pageable pageable);
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
     //List<Post> findAllByMember(Member member);
     Page<Post> findByMemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -19,6 +19,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
     Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
+    Page<Post> findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(Project project, Team team, Pageable pageable);
     boolean existsByTeam(Team team);
     boolean existsByProject(Project project);
     boolean existsByMember(Member member);

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -15,8 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle);
     List<Post> findAllByOrderByCreatedAtDesc();
-    List<Post> findAllByMember(Member member);
-
+    //List<Post> findAllByMember(Member member);
+    Page<Post> findByMemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
     Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
     Page<Post> findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(Project project, Team team, Pageable pageable);

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.codiary.backend.global.repository;
 
 import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
+import com.codiary.backend.global.domain.entity.Project;
 import com.codiary.backend.global.domain.entity.Team;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByMember(Member member);
 
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
+    Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
     boolean existsByTeam(Team team);
+    boolean existsByProject(Project project);
+    boolean existsByMember(Member member);
     List<Post> findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -2,6 +2,9 @@ package com.codiary.backend.global.repository;
 
 import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
+import com.codiary.backend.global.domain.entity.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -13,5 +16,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByOrderByCreatedAtDesc();
     List<Post> findAllByMember(Member member);
 
+    Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
+    boolean existsByTeam(Team team);
     List<Post> findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/codiary/backend/global/repository/ProjectRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.codiary.backend.global.repository;
+
+import com.codiary.backend.global.domain.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -14,6 +14,7 @@ public interface PostQueryService {
     List<Post> findAllBySearch(Optional<String> optSearch);
     List<Post> getMemberPost(Long memberId);
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
+    Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
 
 
     Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -1,6 +1,8 @@
 package com.codiary.backend.global.service.PostService;
 
 import com.codiary.backend.global.domain.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.YearMonth;
 import java.util.List;
@@ -11,6 +13,8 @@ public interface PostQueryService {
 
     List<Post> findAllBySearch(Optional<String> optSearch);
     List<Post> getMemberPost(Long memberId);
+    Page<Post> getPostsByTeam(Long teamId, int page, int size);
+
 
     Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth);
 }

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -15,6 +15,7 @@ public interface PostQueryService {
     List<Post> getMemberPost(Long memberId);
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
+    Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);
 
 
     Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -16,6 +16,7 @@ public interface PostQueryService {
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
     Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);
+    Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size);
 
 
     Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 public interface PostQueryService {
 
     List<Post> findAllBySearch(Optional<String> optSearch);
-    List<Post> getMemberPost(Long memberId);
+    //List<Post> getMemberPost(Long memberId);
+    Page<Post> getPostsByMember(Long memberId, int page, int size);
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
     Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -11,8 +11,9 @@ import java.util.Optional;
 
 public interface PostQueryService {
 
-    List<Post> findAllBySearch(Optional<String> optSearch);
+    //List<Post> findAllBySearch(Optional<String> optSearch);
     //List<Post> getMemberPost(Long memberId);
+    Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size);
     Page<Post> getPostsByMember(Long memberId, int page, int size);
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -66,7 +66,6 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
     }
 
-
     @Override
     public Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
@@ -81,6 +80,22 @@ public class PostQueryServiceImpl implements PostQueryService {
         }
         return postRepository.findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(project, member, request);
     }
+
+    @Override
+    public Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Project project = projectRepository.findById(projectId).get();
+        Team team = teamRepository.findById(teamId).get();
+
+        if (!postRepository.existsByProject(project)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_PROJECT);
+        }
+        if (!postRepository.existsByTeam(team)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
+        }
+        return postRepository.findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(project, team, request);
+    }
+
 
     @Override
     public Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth) {

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -5,9 +5,11 @@ import com.codiary.backend.global.apiPayload.exception.GeneralException;
 import com.codiary.backend.global.apiPayload.exception.handler.PostHandler;
 import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
+import com.codiary.backend.global.domain.entity.Project;
 import com.codiary.backend.global.domain.entity.Team;
 import com.codiary.backend.global.repository.MemberRepository;
 import com.codiary.backend.global.repository.PostRepository;
+import com.codiary.backend.global.repository.ProjectRepository;
 import com.codiary.backend.global.repository.TeamRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final MemberRepository memberRepository;
     private final TeamRepository teamRepository;
     private final PostRepository postRepository;
+    private final ProjectRepository projectRepository;
 
     @Override
     public List<Post> findAllBySearch(Optional<String> optSearch) {
@@ -63,6 +66,21 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
     }
 
+
+    @Override
+    public Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Project project = projectRepository.findById(projectId).get();
+        Member member = memberRepository.findById(memberId).get();
+
+        if (!postRepository.existsByProject(project)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_PROJECT);
+        }
+        if (!postRepository.existsByMember(member)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
+        }
+        return postRepository.findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(project, member, request);
+    }
 
     @Override
     public Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth) {

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -2,13 +2,18 @@ package com.codiary.backend.global.service.PostService;
 
 import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
 import com.codiary.backend.global.apiPayload.exception.GeneralException;
+import com.codiary.backend.global.apiPayload.exception.handler.PostHandler;
 import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
+import com.codiary.backend.global.domain.entity.Team;
 import com.codiary.backend.global.repository.MemberRepository;
 import com.codiary.backend.global.repository.PostRepository;
+import com.codiary.backend.global.repository.TeamRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +29,7 @@ import java.util.*;
 public class PostQueryServiceImpl implements PostQueryService {
 
     private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
     private final PostRepository postRepository;
 
     @Override
@@ -45,6 +51,18 @@ public class PostQueryServiceImpl implements PostQueryService {
 
         return MemberPostList;
     }
+
+    @Override
+    public Page<Post> getPostsByTeam(Long teamId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Team team = teamRepository.findById(teamId).get();
+
+        if (!postRepository.existsByTeam(team)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
+        }
+        return postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
+    }
+
 
     @Override
     public Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth) {

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -36,15 +36,16 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final ProjectRepository projectRepository;
 
     @Override
-    public List<Post> findAllBySearch(Optional<String> optSearch) {
+    public Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
         // 만약 검색어가 존재한다면
         if (optSearch.isPresent()) {
             String search = optSearch.get();
 
-            return postRepository.findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(search);
+            return postRepository.findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(search, request);
         }
         // 검색어 존재 X
-        return postRepository.findAllByOrderByCreatedAtDesc();
+        return postRepository.findAllByOrderByCreatedAtDesc(request);
     }
 
     @Override

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -96,6 +96,21 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postRepository.findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(project, team, request);
     }
 
+    @Override
+    public Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Team team = teamRepository.findById(teamId).get();
+        Member member = memberRepository.findById(memberId).get();
+
+        if (!postRepository.existsByTeam(team)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
+        }
+        if (!postRepository.existsByMember(member)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
+        }
+        return postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, member, request);
+    }
+
 
     @Override
     public Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth) {

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -48,11 +48,14 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public List<Post> getMemberPost(Long memberId) {
-        Member getMember = memberRepository.findById(memberId).get();
-        List<Post> MemberPostList = postRepository.findAllByMember(getMember);
+    public Page<Post> getPostsByMember(Long memberId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Member member = memberRepository.findById(memberId).get();
 
-        return MemberPostList;
+        if (!postRepository.existsByMember(member)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
+        }
+        return postRepository.findByMemberOrderByCreatedAtDescPostIdDesc(member, request);
     }
 
     @Override

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -241,19 +241,20 @@ public class PostController {
     }
 
     // 제목으로 다이어리 페이징 조회
-    // TODO: 페이징 조회로 수정 필요
     @GetMapping("/title/paging")
     @Operation(
-            summary = "제목으로 다이어리 전체 리스트 조회 API", description = "제목으로 다이어리 전체 리스트 조회합니다. Param으로 제목을 입력하세요"
+            summary = "제목으로 다이어리 페이징 조회 API", description = "제목으로 다이어리를 페이징으로 조회합니다. Param으로 제목을 입력하세요."
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<?> findPostsByTitle(
-            @RequestParam Optional<String> search
-    ){
-        List<Post> Posts = postQueryService.findAllBySearch(search);
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByTitle(
+            @RequestParam Optional<String> search,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
+    ) {
+        Page<Post> posts = postQueryService.getPostsByTitle(Optional.of(search.orElse("")), page, size);
         return ApiResponse.onSuccess(
                 SuccessStatus.POST_OK,
-                PostConverter.toPostPreviewListDTO(Posts)
+                PostConverter.toPostPreviewListDTO(posts)
         );
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -9,8 +9,6 @@ import com.codiary.backend.global.service.PostService.PostQueryService;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
 import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -172,25 +170,32 @@ public class PostController {
             @RequestParam @Min(0) Integer page,
             @RequestParam @Min(1) @Max(5) Integer size
     ){
-        log.info("Finding posts by team with ID: {}, Page: {}, Size: {}", teamId, page, size);
         Page<Post> posts = postQueryService.getPostsByTeam(teamId, page, size);
-        log.info("Number of posts found: {}", posts.getTotalElements());
 
         return ApiResponse.onSuccess(
                 SuccessStatus.POST_OK,
-                PostConverter.toTeamPostPreviewDTOList(posts)
+                PostConverter.toTeamPostPreviewListDTO(posts)
         );
     }
 
     // 프로젝트별 저자의 다이어리 페이징 조회
     @GetMapping("/project/{projectId}/member/{memberId}/paging")
     @Operation(
-            summary = "프로젝트별 저자의 다이어리 페이징 조회 API", description = "프로젝트별 저자의 다이어리 페이징 조회합니다."
+            summary = "프로젝트별 저자의 다이어리 페이징 조회 API", description = "프로젝트별 저자의 다이어리를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> findPostByMemberInProject(
+    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(
+            @PathVariable Long projectId,
+            @PathVariable Long memberId,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ){
-        return null;
+        Page<Post> posts = postQueryService.getPostsByMemberInProject(projectId, memberId, page, size);
+
+        return ApiResponse.onSuccess(
+                SuccessStatus.POST_OK,
+                PostConverter.toMemberPostInProjectPreviewListDTO(posts)
+        );
     }
 
     // 프로젝트별 팀의 다이어리 페이징 조회

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -140,22 +140,24 @@ public class PostController {
 
 
     // 저자의 다이어리 페이징 조회
-    // TODO: 페이징 조회로 수정 필요
     // TODO: 멤버별 작성한 글 조회시 공동 저자로 등록된 멤버도 조회가능하도록 기능 수정 필요
     @GetMapping("/member/{memberId}/paging")
     @Operation(
-            summary = "저자의 다이어리 전체 리스트 조회 API", description = "로그인된 멤버가 작성한 모든 글을 조회할 수 있습니다."
+            summary = "저자의 다이어리 페이징 조회 API", description = "저자의 다이어리를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.MemberPostResultListDTO> findMemberPost(
-            @PathVariable Long memberId
+    public ApiResponse<PostResponseDTO.MemberPostPreviewListDTO> findPostByMember(
+            @PathVariable Long memberId,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ) {
         // 토큰 유효성 검사 (memberId)
         //jwtTokenProvider.isValidToken(memberId);
-        List<Post> memberPostList = postQueryService.getMemberPost(memberId);
+        //List<Post> memberPostList = postQueryService.getMemberPost(memberId);
+        Page<Post> posts = postQueryService.getPostsByMember(memberId, page, size);
         return ApiResponse.onSuccess(
                 SuccessStatus.POST_OK,
-                PostConverter.toMemberPostResultListDTO(memberPostList)
+                PostConverter.toMemberPostPreviewListDTO(posts)
         );
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -201,12 +201,21 @@ public class PostController {
     // 프로젝트별 팀의 다이어리 페이징 조회
     @GetMapping("/project/{projectId}/team/{teamId}/paging")
     @Operation(
-            summary = "프로젝트별 팀의 다이어리 페이징 조회 API", description = "프로젝트별 팀의 다이어리 페이징 조회합니다."
+            summary = "프로젝트별 팀의 다이어리 페이징 조회 API", description = "프로젝트별 팀의 다이어리를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> findPostByTeamInProject(
+    public ApiResponse<PostResponseDTO.TeamPostInProjectPreviewListDTO> findPostByTeamInProject(
+            @PathVariable Long projectId,
+            @PathVariable Long teamId,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ){
-        return null;
+        Page<Post> posts = postQueryService.getPostsByTeamInProject(projectId, teamId, page, size);
+
+        return ApiResponse.onSuccess(
+                SuccessStatus.POST_OK,
+                PostConverter.toTeamPostInProjectPreviewListDTO(posts)
+        );
     }
 
     // 팀별 저자의 다이어리 페이징 조회

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -221,13 +221,21 @@ public class PostController {
     // 팀별 저자의 다이어리 페이징 조회
     @GetMapping("/team/{teamId}/member/{memberId}/paging")
     @Operation(
-            summary = "팀별 저자의 다이어리 페이징 조회 API"
-            , description = "팀별 저자의 다이어리 페이징 조회합니다."
+            summary = "팀별 저자의 다이어리 페이징 조회 API", description = "팀별 저자의 다이어리를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> findPostByMemberInTeam(
+    public ApiResponse<PostResponseDTO.MemberPostInTeamPreviewListDTO> findPostByMemberInTeam(
+            @PathVariable Long teamId,
+            @PathVariable Long memberId,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ){
-        return null;
+        Page<Post> posts = postQueryService.getPostsByMemberInTeam(teamId, memberId, page, size);
+
+        return ApiResponse.onSuccess(
+                SuccessStatus.POST_OK,
+                PostConverter.toMemberPostInTeamPreviewListDTO(posts)
+        );
     }
 
     // 제목으로 다이어리 페이징 조회

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -9,9 +9,13 @@ import com.codiary.backend.global.service.PostService.PostQueryService;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
 import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -140,7 +144,7 @@ public class PostController {
     // 저자의 다이어리 페이징 조회
     // TODO: 페이징 조회로 수정 필요
     // TODO: 멤버별 작성한 글 조회시 공동 저자로 등록된 멤버도 조회가능하도록 기능 수정 필요
-    @GetMapping("/paging/{memberId}")
+    @GetMapping("/member/{memberId}/paging")
     @Operation(
             summary = "저자의 다이어리 전체 리스트 조회 API", description = "로그인된 멤버가 작성한 모든 글을 조회할 수 있습니다."
             //, security = @SecurityRequirement(name = "accessToken")
@@ -158,18 +162,28 @@ public class PostController {
     }
 
     // 팀의 다이어리 페이징 조회
-    @GetMapping("/paging/{teamId}")
+    @GetMapping("/team/{teamId}/paging")
     @Operation(
-            summary = "팀의 다이어리 페이징 조회 API", description = "팀의 다이어리 페이징 조회합니다."
+            summary = "팀의 다이어리 페이징 조회 API", description = "팀의 다이어리를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> findPostByTeam(
+    public ApiResponse<PostResponseDTO.TeamPostPreviewListDTO> findPostByTeam(
+            @PathVariable Long teamId,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ){
-        return null;
+        log.info("Finding posts by team with ID: {}, Page: {}, Size: {}", teamId, page, size);
+        Page<Post> posts = postQueryService.getPostsByTeam(teamId, page, size);
+        log.info("Number of posts found: {}", posts.getTotalElements());
+
+        return ApiResponse.onSuccess(
+                SuccessStatus.POST_OK,
+                PostConverter.toTeamPostPreviewDTOList(posts)
+        );
     }
 
     // 프로젝트별 저자의 다이어리 페이징 조회
-    @GetMapping("/paging/{projectId}/{memberId}")
+    @GetMapping("/project/{projectId}/member/{memberId}/paging")
     @Operation(
             summary = "프로젝트별 저자의 다이어리 페이징 조회 API", description = "프로젝트별 저자의 다이어리 페이징 조회합니다."
             //, security = @SecurityRequirement(name = "accessToken")
@@ -180,7 +194,7 @@ public class PostController {
     }
 
     // 프로젝트별 팀의 다이어리 페이징 조회
-    @GetMapping("/paging/{projectId}/{teamId}")
+    @GetMapping("/project/{projectId}/team/{teamId}/paging")
     @Operation(
             summary = "프로젝트별 팀의 다이어리 페이징 조회 API", description = "프로젝트별 팀의 다이어리 페이징 조회합니다."
             //, security = @SecurityRequirement(name = "accessToken")
@@ -191,7 +205,7 @@ public class PostController {
     }
 
     // 팀별 저자의 다이어리 페이징 조회
-    @GetMapping("/paging/{teamId}/{memberId}")
+    @GetMapping("/team/{teamId}/member/{memberId}/paging")
     @Operation(
             summary = "팀별 저자의 다이어리 페이징 조회 API"
             , description = "팀별 저자의 다이어리 페이징 조회합니다."
@@ -204,7 +218,7 @@ public class PostController {
 
     // 제목으로 다이어리 페이징 조회
     // TODO: 페이징 조회로 수정 필요
-    @GetMapping("/paging/title")
+    @GetMapping("/title/paging")
     @Operation(
             summary = "제목으로 다이어리 전체 리스트 조회 API", description = "제목으로 다이어리 전체 리스트 조회합니다. Param으로 제목을 입력하세요"
             //, security = @SecurityRequirement(name = "accessToken")
@@ -220,7 +234,7 @@ public class PostController {
     }
 
     // 카테고리명으로 다이어리 페이징 조회
-    @GetMapping("/paging/category")
+    @GetMapping("/category/paging")
     @Operation(
             summary = "카테고리명으로 다이어리 페이징 조회 API", description = "카테고리명으로 다이어리 페이징 조회합니다."
             //, security = @SecurityRequirement(name = "accessToken")

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -1,5 +1,6 @@
 package com.codiary.backend.global.web.dto.Post;
 
+import com.codiary.backend.global.domain.enums.PostAccess;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,12 +18,14 @@ public class PostResponseDTO {
     @NoArgsConstructor
     public static class CreatePostResultDTO {
         Long postId;
+        Long teamId;
         String postTitle;
         //String postBody;
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
-        Long teamId;
+        PostAccess postAccess;
+
     }
 
     @Getter
@@ -31,12 +34,13 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class UpdatePostResultDTO {
         Long postId;
+        Long teamId;
         String postTitle;
         //String postBody;
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
-        Long teamId;
+        PostAccess postAccess;
     }
 
     @Getter
@@ -46,13 +50,14 @@ public class PostResponseDTO {
     public static class PostPreviewDTO { // Post 조회
         Long postId;
         Long memberId;
+        Long teamId;
         String postTitle;
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
-        Long teamId;
+        PostAccess postAccess;
     }
 
     @Getter
@@ -75,11 +80,12 @@ public class PostResponseDTO {
     public static class MemberPostResultDTO { // 저자별 Post 조회
         Long memberId;
         Long postId;
+        Long teamId;
         String postTitle;
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
-        Long teamId;
+        PostAccess postAccess;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -105,6 +111,7 @@ public class PostResponseDTO {
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
+        PostAccess postAccess;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -135,6 +142,7 @@ public class PostResponseDTO {
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
+        PostAccess postAccess;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -145,6 +153,37 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class MemberPostInProjectPreviewListDTO { // 프로젝트별 저자의 Post 리스트 조회
         List<MemberPostInProjectPreviewDTO> posts;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeamPostInProjectPreviewDTO { // 프로젝트별 팀의 Post 조회
+        Long projectId;
+        Long teamId;
+        Long postId;
+        Long memberId;
+        String postTitle;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeamPostInProjectPreviewListDTO { // 프로젝트별 팀의 Post 리스트 조회
+        List<TeamPostInProjectPreviewDTO> posts;
         Integer listSize;
         Integer totalPage;
         Long totalElements;

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -18,7 +18,9 @@ public class PostResponseDTO {
     @NoArgsConstructor
     public static class CreatePostResultDTO {
         Long postId;
+        Long memberId;
         Long teamId;
+        Long projectId;
         String postTitle;
         //String postBody;
         Boolean postStatus;
@@ -34,7 +36,9 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class UpdatePostResultDTO {
         Long postId;
+        Long memberId;
         Long teamId;
+        Long projectId;
         String postTitle;
         //String postBody;
         Boolean postStatus;
@@ -51,6 +55,7 @@ public class PostResponseDTO {
         Long postId;
         Long memberId;
         Long teamId;
+        Long projectId;
         String postTitle;
         Boolean postStatus;
         String postCategory;
@@ -66,21 +71,22 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class PostPreviewListDTO { // 전체 Post 리스트 조회
         List<PostPreviewDTO> posts;
-        //Integer listSize;
-        //Integer totalPage;
-        //Long totalElements;
-        //boolean isFirst;
-        //boolean isLast;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberPostResultDTO { // 저자별 Post 조회
+    public static class MemberPostPreviewDTO { // 저자별 Post 조회
         Long memberId;
         Long postId;
         Long teamId;
+        Long projectId;
         String postTitle;
         Boolean postStatus;
         String postCategory;
@@ -94,8 +100,13 @@ public class PostResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberPostResultListDTO { // 저자별 Post 리스트 조회
-        List<MemberPostResultDTO> posts;
+    public static class MemberPostPreviewListDTO { // 저자별 Post 리스트 조회
+        List<MemberPostPreviewDTO> posts;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
     }
 
 
@@ -107,6 +118,7 @@ public class PostResponseDTO {
         Long teamId;
         Long postId;
         Long memberId;
+        Long projectId;
         String postTitle;
         Boolean postStatus;
         String postCategory;
@@ -199,6 +211,7 @@ public class PostResponseDTO {
         Long teamId;
         Long memberId;
         Long postId;
+        Long projectId;
         String postTitle;
         Boolean postStatus;
         String postCategory;

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -43,7 +43,7 @@ public class PostResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PostPreviewDTO {
+    public static class PostPreviewDTO { // Post 조회
         Long postId;
         Long memberId;
         String postTitle;
@@ -59,15 +59,21 @@ public class PostResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PostPreviewListDTO {
+    public static class PostPreviewListDTO { // 전체 Post 리스트 조회
         List<PostPreviewDTO> posts;
+        //Integer listSize;
+        //Integer totalPage;
+        //Long totalElements;
+        //boolean isFirst;
+        //boolean isLast;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberPostResultDTO {
+    public static class MemberPostResultDTO { // 저자별 Post 조회
+        Long memberId;
         Long postId;
         String postTitle;
         Boolean postStatus;
@@ -82,8 +88,38 @@ public class PostResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberPostResultListDTO {
+    public static class MemberPostResultListDTO { // 저자별 Post 리스트 조회
         List<MemberPostResultDTO> posts;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeamPostPreviewDTO { // 팀별 Post 조회
+        Long teamId;
+        Long postId;
+        Long memberId;
+        String postTitle;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeamPostPreviewListDTO { // 팀별 Post 리스트 조회
+        List<TeamPostPreviewDTO> posts;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
     }
 
 }

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -191,4 +191,35 @@ public class PostResponseDTO {
         boolean isLast;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPostInTeamPreviewDTO { // 팀별 멤버의 Post 조회
+        Long teamId;
+        Long memberId;
+        Long postId;
+        String postTitle;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPostInTeamPreviewListDTO { // 팀별 멤버의 Post 리스트 조회
+        List<MemberPostInTeamPreviewDTO> posts;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
+    }
+
 }
+

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -122,4 +122,34 @@ public class PostResponseDTO {
         boolean isLast;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPostInProjectPreviewDTO { // 프로젝트별 저자의 Post 조회
+        Long projectId;
+        Long memberId;
+        Long postId;
+        Long teamId;
+        String postTitle;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPostInProjectPreviewListDTO { // 프로젝트별 저자의 Post 리스트 조회
+        List<MemberPostInProjectPreviewDTO> posts;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        boolean isFirst;
+        boolean isLast;
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #34

## 📝작업 내용
> 다이어리 조회 관련 API에서 결과 리스트를 페이징으로 조회하도록 구현 및 수정
> - 저자의 다이어리 조회 (memberId) -> 리스트를 페이징으로 조회하도록 변경 완료
> - 팀의 다이어리 조회 (teamId)
> - 프로젝트별 저자의 다이어리 조회 (projectId, memberId)
> - 프로젝트별 팀의 다이어리 조회 (projectId, teamId)
> - 팀별 저자의 다이어리 조회 (teamId, memberId)
> - 다이어리 제목으로 조회 (postTitle) -> 리스트를 페이징으로 조회하도록 변경 완료

> 카테고리명으로 다이어리 조회 (category) -> 추후 예정

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
