### PR TITLE
Feat: 캘린더 조회 데이터 변경 및 프로젝트 별 글 제목 조회 기능 추가

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/CalendarConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/CalendarConverter.java
@@ -1,0 +1,27 @@
+package com.codiary.backend.global.converter;
+
+import com.codiary.backend.global.domain.entity.Post;
+import com.codiary.backend.global.web.dto.Calendar.CalendarDTO;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CalendarConverter {
+    public static CalendarDTO toCalendarDTO(List<Post> postList) {
+        Map<String, List<String[]>> projectActivities = new HashMap<>();
+
+        postList.forEach(post -> {
+            String date = post.getCreatedAt().toLocalDate().toString();
+            String projectName = post.getProject().getProjectName();
+            String postTitle = post.getPostTitle();
+            String[] activityDetail = {projectName, postTitle};
+            projectActivities.computeIfAbsent(date, k -> new ArrayList<>()).add(activityDetail);
+        });
+
+        return CalendarDTO.builder()
+                .projectActivities(projectActivities)
+                .build();
+    }
+}

--- a/src/main/java/com/codiary/backend/global/converter/CalendarConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/CalendarConverter.java
@@ -9,19 +9,35 @@ import java.util.List;
 import java.util.Map;
 
 public class CalendarConverter {
-    public static CalendarDTO toCalendarDTO(List<Post> postList) {
-        Map<String, List<String[]>> projectActivities = new HashMap<>();
+
+    public static CalendarDTO.ToCalendarDTO toCalendarDTO(List<Post> postList) {
+        Map<String, List<String[]>> activities = new HashMap<>();
 
         postList.forEach(post -> {
             String date = post.getCreatedAt().toLocalDate().toString();
             String projectName = post.getProject().getProjectName();
             String postTitle = post.getPostTitle();
             String[] activityDetail = {projectName, postTitle};
-            projectActivities.computeIfAbsent(date, k -> new ArrayList<>()).add(activityDetail);
+            activities.computeIfAbsent(date, k -> new ArrayList<>()).add(activityDetail);
         });
 
-        return CalendarDTO.builder()
-                .projectActivities(projectActivities)
+        return CalendarDTO.ToCalendarDTO.builder()
+                .projectAndTitlesByDate(activities)
+                .build();
+    }
+
+    public static CalendarDTO.ToProjectDTO toProjectsDTO(List<Post> postList) {
+        Map<String, List<String>> activities = new HashMap<>();
+
+        postList.forEach(post -> {
+            String projectName = post.getProject().getProjectName();
+            String postTitle = post.getPostTitle();
+            activities.computeIfAbsent(projectName, k -> new ArrayList<>()).add(postTitle);
+        });
+
+        return CalendarDTO.ToProjectDTO.builder()
+                .titlesByProject(activities)
                 .build();
     }
 }
+

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -2,7 +2,9 @@ package com.codiary.backend.global.repository;
 
 import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,5 +15,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByOrderByCreatedAtDesc();
     List<Post> findAllByMember(Member member);
 
-    List<Post> findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime startDate, LocalDateTime endDate);
+    @EntityGraph(attributePaths = {"project"})
+    List<Post> findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(@Param("member") Member member, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -4,7 +4,6 @@ import com.codiary.backend.global.domain.entity.Post;
 
 import java.time.YearMonth;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface PostQueryService {
@@ -12,5 +11,5 @@ public interface PostQueryService {
     List<Post> findAllBySearch(Optional<String> optSearch);
     List<Post> getMemberPost(Long memberId);
 
-    Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth);
+    List<Post> getPostsByMonth(Long memberId, YearMonth yearMonth);
 }

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -55,6 +55,8 @@ public class PostQueryServiceImpl implements PostQueryService {
         LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
         List<Post> posts = postRepository.findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, startDate, endDate);
 
+        posts.forEach(post -> post.getProject());
+
         return posts;
     }
 }

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -47,7 +47,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public Map<String, List<String>> getPostsByMonth(Long memberId, YearMonth yearMonth) {
+    public List<Post> getPostsByMonth(Long memberId, YearMonth yearMonth) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
@@ -55,14 +55,6 @@ public class PostQueryServiceImpl implements PostQueryService {
         LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
         List<Post> posts = postRepository.findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, startDate, endDate);
 
-        Map<String, List<String>> projectActivities = new HashMap<>();
-
-        posts.forEach(post -> {
-            String date = post.getCreatedAt().toLocalDate().toString();
-            String projectName = post.getProject().getProjectName();
-            projectActivities.computeIfAbsent(date, k -> new ArrayList<>()).add(projectName);
-        });
-
-        return projectActivities;
+        return posts;
     }
 }

--- a/src/main/java/com/codiary/backend/global/web/controller/CalendarController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/CalendarController.java
@@ -8,7 +8,7 @@ import com.codiary.backend.global.converter.CalendarConverter;
 import com.codiary.backend.global.domain.entity.Post;
 import com.codiary.backend.global.service.PostService.PostQueryService;
 import com.codiary.backend.global.web.dto.Calendar.CalendarDTO;
-import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +25,13 @@ public class CalendarController {
 
     private final PostQueryService postQueryService;
 
-    //TODO: 로그인 구현 완료 시 principal 추가 필요
+    @Operation(
+            summary = "해당 달의 캘린더 조회 API"
+            , description = "날짜별로 프로젝트명 및 글 제목을 반환합니다. 조회하고자 하는 연도와 월을 입력해주세요."
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
     @GetMapping("")
-    public ApiResponse<CalendarDTO> getRecentPosts(@RequestParam("year") String year, @RequestParam("month") String month) {
+    public ApiResponse<CalendarDTO.ToCalendarDTO> getRecentPosts(@RequestParam("year") String year, @RequestParam("month") String month) {
         try {
             int yearInt = Integer.parseInt(year);
             int monthInt = Integer.parseInt(month);
@@ -39,6 +43,30 @@ public class CalendarController {
             return ApiResponse.onSuccess(
                     SuccessStatus.POST_OK,
                     CalendarConverter.toCalendarDTO(postList)
+            );
+        } catch (NumberFormatException e) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+    }
+
+    @Operation(
+            summary = "해당 달의 프로젝트 및 글 제목 조회 API"
+            , description = "해당 달의 프로젝트 별 글 제목을 반환합니다. 조회하고자 하는 연도와 월을 입력해주세요."
+            //, security = @SecurityRequirement(name = "accessToken")
+    )
+    @GetMapping("/project")
+    public ApiResponse<CalendarDTO.ToProjectDTO> getRecentProjects(@RequestParam("year") String year, @RequestParam("month") String month) {
+        try {
+            int yearInt = Integer.parseInt(year);
+            int monthInt = Integer.parseInt(month);
+
+            YearMonth yearMonth = YearMonth.of(yearInt, monthInt);
+            Long memberId = 1L;
+
+            List<Post> postList = postQueryService.getPostsByMonth(memberId, yearMonth);
+            return ApiResponse.onSuccess(
+                    SuccessStatus.POST_OK,
+                    CalendarConverter.toProjectsDTO(postList)
             );
         } catch (NumberFormatException e) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);

--- a/src/main/java/com/codiary/backend/global/web/controller/CalendarController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/CalendarController.java
@@ -1,8 +1,14 @@
 package com.codiary.backend.global.web.controller;
 
+import com.codiary.backend.global.apiPayload.ApiResponse;
 import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
+import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
 import com.codiary.backend.global.apiPayload.exception.GeneralException;
+import com.codiary.backend.global.converter.CalendarConverter;
+import com.codiary.backend.global.domain.entity.Post;
 import com.codiary.backend.global.service.PostService.PostQueryService;
+import com.codiary.backend.global.web.dto.Calendar.CalendarDTO;
+import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.YearMonth;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/calendar")
@@ -22,7 +27,7 @@ public class CalendarController {
 
     //TODO: 로그인 구현 완료 시 principal 추가 필요
     @GetMapping("")
-    public Map<String, List<String>> getRecentPosts( @RequestParam("year") String year, @RequestParam("month") String month) {
+    public ApiResponse<CalendarDTO> getRecentPosts(@RequestParam("year") String year, @RequestParam("month") String month) {
         try {
             int yearInt = Integer.parseInt(year);
             int monthInt = Integer.parseInt(month);
@@ -30,7 +35,11 @@ public class CalendarController {
             YearMonth yearMonth = YearMonth.of(yearInt, monthInt);
             Long memberId = 1L;
 
-            return postQueryService.getPostsByMonth(memberId, yearMonth);
+            List<Post> postList = postQueryService.getPostsByMonth(memberId, yearMonth);
+            return ApiResponse.onSuccess(
+                    SuccessStatus.POST_OK,
+                    CalendarConverter.toCalendarDTO(postList)
+            );
         } catch (NumberFormatException e) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }

--- a/src/main/java/com/codiary/backend/global/web/dto/Calendar/CalendarDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Calendar/CalendarDTO.java
@@ -1,0 +1,17 @@
+package com.codiary.backend.global.web.dto.Calendar;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarDTO {
+    private Map<String, List<String[]>> projectActivities;
+}

--- a/src/main/java/com/codiary/backend/global/web/dto/Calendar/CalendarDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Calendar/CalendarDTO.java
@@ -8,10 +8,21 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class CalendarDTO {
-    private Map<String, List<String[]>> projectActivities;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ToCalendarDTO {
+        private Map<String, List<String[]>> projectAndTitlesByDate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ToProjectDTO {
+        private Map<String, List<String>> titlesByProject;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
#30

## 📝작업 내용
> 
- 캘린더 조회 코드 dto 및 converter추가
- 캘린더 조회 시 글 제목도 조회할 수 있도록 추가
- 조회한 달의 프로젝트 별 글 제목 조회 기능 추가

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
