### PR TITLE
Feat: 카테고리명으로 다이어리 리스트 페이징 조회 기능 구현 & Refactor: Post, Categories, Member 엔티티 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -27,27 +27,33 @@ public class PostConverter {
 //    }
 
     public static Post toPost(PostRequestDTO.CreatePostRequestDTO request) {
-        //List<String> postCategories = new ArrayList<>(request.getPostCategory());
+        List<Categories> categories = request.getPostCategory().stream()
+                .map(Categories::new) // Assuming Categories has a constructor that accepts String
+                .collect(Collectors.toList());
+
         return Post.builder()
                 .postTitle(request.getPostTitle())
                 .postBody(request.getPostBody())
                 .postStatus(request.getPostStatus())
-                .postCategory(new ArrayList<>(request.getPostCategory()))
+                .categoriesList(categories)
                 .postAccess(request.getPostAccess())
                 .build();
     }
 
     public static PostResponseDTO.CreatePostResultDTO toCreateResultDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.CreatePostResultDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -57,16 +63,19 @@ public class PostConverter {
     }
 
     public static PostResponseDTO.UpdatePostResultDTO toUpdatePostResultDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.UpdatePostResultDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -76,16 +85,19 @@ public class PostConverter {
 
     // Post 조회
     public static PostResponseDTO.PostPreviewDTO toPostPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostPreviewDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -113,16 +125,19 @@ public class PostConverter {
 
     // 저자별 Post 조회
     public static PostResponseDTO.MemberPostPreviewDTO toMemberPostPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.MemberPostPreviewDTO.builder()
                 .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -131,6 +146,7 @@ public class PostConverter {
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
+
     // 저자별 Post 페이징 조회
     public static PostResponseDTO.MemberPostPreviewListDTO toMemberPostPreviewListDTO(Page<Post> posts) {
         List<PostResponseDTO.MemberPostPreviewDTO> memberPostPreviewDTOList = posts.getContent().stream()
@@ -149,16 +165,19 @@ public class PostConverter {
 
     // 팀별 Post 조회
     public static PostResponseDTO.TeamPostPreviewDTO toTeamPostPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.TeamPostPreviewDTO.builder()
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -187,7 +206,10 @@ public class PostConverter {
 
     // 프로젝트별 저자의 Post 조회
     public static PostResponseDTO.MemberPostInProjectPreviewDTO toMemberPostInProjectPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.MemberPostInProjectPreviewDTO.builder()
                 .projectId(post.getProject().getProjectId())
                 .memberId(post.getMember().getMemberId())
@@ -196,7 +218,7 @@ public class PostConverter {
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -224,7 +246,10 @@ public class PostConverter {
 
     // 프로젝트별 팀의 Post 조회
     public static PostResponseDTO.TeamPostInProjectPreviewDTO toTeamPostInProjectPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.TeamPostInProjectPreviewDTO.builder()
                 .projectId(post.getProject().getProjectId())
                 .teamId(post.getTeam().getTeamId())
@@ -233,7 +258,7 @@ public class PostConverter {
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -261,7 +286,10 @@ public class PostConverter {
 
     // 팀별 멤버의 Post 조회
     public static PostResponseDTO.MemberPostInTeamPreviewDTO toMemberPostInTeamPreviewDTO(Post post) {
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.MemberPostInTeamPreviewDTO.builder()
                 .teamId(post.getTeam().getTeamId())
                 .memberId(post.getMember().getMemberId())
@@ -270,7 +298,7 @@ public class PostConverter {
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -300,16 +328,19 @@ public class PostConverter {
     public static PostResponseDTO.PostAdjacentDTO.PostAdjacentPreviewDTO toPostAdjacentPreviewDTO(Post post) {
         if (post == null) return null;
 
-        //List<String> postCategories = convertCategoriesToCategoryNames(post.getPostCategory());
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostAdjacentDTO.PostAdjacentPreviewDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", post.getPostCategory()))
+                .postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))

--- a/src/main/java/com/codiary/backend/global/domain/entity/Member.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Member.java
@@ -72,8 +72,8 @@ public class Member extends BaseEntity {
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<MemberProjectMap> memberProjectMapList = new ArrayList<>();
 
-  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Categories> catecoriesList = new ArrayList<>();
+//  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//  private List<Categories> catecoriesList = new ArrayList<>();
 
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> commentList = new ArrayList<>();

--- a/src/main/java/com/codiary/backend/global/domain/entity/Post.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Post.java
@@ -37,13 +37,6 @@ public class Post extends BaseEntity {
   @JoinColumn(name = "project_id")
   private Project project;
 
-  @ElementCollection
-  @CollectionTable(name = "post_category", joinColumns = @JoinColumn(name = "post_id"))
-  @Column(name = "category_name")
-  private List<String> postCategory = new ArrayList<>();
-  //@Column(name = "post_category",  columnDefinition = "varchar(500)")
-  //private String postCategory;
-
   @Column(name = "post_title", nullable = false, columnDefinition = "varchar(500)")
   private String postTitle;
 
@@ -58,13 +51,27 @@ public class Post extends BaseEntity {
   @Column(name = "post_status", nullable = false, columnDefinition = "tinyint")
   private Boolean postStatus;
 
+
+//  @ElementCollection
+//  @CollectionTable(name = "post_category", joinColumns = @JoinColumn(name = "post_id"))
+//  @Column(name = "category_name")
+//  private List<String> postCategory = new ArrayList<>();
+//
+//  @Builder.Default
+//  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+//  private List<Categories> categoriesList = new ArrayList<>();
   @Builder.Default
-  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<PostFile> postFileList = new ArrayList<>();
+  @ManyToMany
+  @JoinTable(
+          name = "post_category",
+          joinColumns = @JoinColumn(name = "post_id"),
+          inverseJoinColumns = @JoinColumn(name = "category_id")
+  )
+  private List<Categories> categoriesList = new ArrayList<>();
 
   @Builder.Default
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Categories> categoriesList = new ArrayList<>();
+  private List<PostFile> postFileList = new ArrayList<>();
 
   @Builder.Default
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -75,24 +82,18 @@ public class Post extends BaseEntity {
   private List<Comment> commentList = new ArrayList<>();
 
 
-  public void setMember(Member member) {
-    this.member = member;
-  }
-
-  public void setTeam(Team team) {
-    this.team = team;
-  }
-
+  public void setMember(Member member) { this.member = member;}
+  public void setTeam(Team team) { this.team = team;}
   public void setProject(Project project) { this.project = project;}
 
   public void update(PostRequestDTO.UpdatePostDTO request) {
     this.postTitle = request.getPostTitle();
     this.postBody = request.getPostBody();
     this.postAccess = request.getPostAccess();
-    Set<Categories> categorySet = request.getPostCategory().stream()
+    List<Categories> categoryList = request.getPostCategory().stream()
             .map(categoryName -> Categories.createCategory(this, categoryName, this.member))
-            .collect(Collectors.toSet());
-    setCategories(categorySet);
+            .collect(Collectors.toList());
+    setCategories(categoryList);
     this.postStatus = request.getPostStatus();
   }
 
@@ -100,14 +101,9 @@ public class Post extends BaseEntity {
     this.postStatus = postStatus;
   }
 
-  public void setCategories(Set<Categories> categories) {
-    // Convert Set<Categories> to List<String>
-    List<String> categoryNames = categories.stream()
-            .map(Categories::getName)  // Extract category name from Categories
-            .collect(Collectors.toList());
-
-    // Set the categories list
-    this.postCategory = categoryNames; // Assuming postCategory is a List<String>
+  public void setCategories(List<Categories> categories) {
+    this.categoriesList.clear();
+    this.categoriesList.addAll(categories);
   }
 
   @Builder

--- a/src/main/java/com/codiary/backend/global/domain/entity/mapping/Categories.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/mapping/Categories.java
@@ -5,6 +5,9 @@ import com.codiary.backend.global.domain.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,38 +17,27 @@ public class Categories {
   @Column(name = "category_id", nullable = false, columnDefinition = "bigint")
   private Long categoryId;
 
-  //우선 String으로 설정, Category 나오면 enum으로 변경 필요
   //@Enumerated(EnumType.STRING)
   @Column(name = "name", nullable = false, columnDefinition = "varchar(100)")
   private String name;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
-  private Member member;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "member_id")
+//  private Member member;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id")
-  private Post post;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "post_id")
+//  private Post post;
+  @ManyToMany(mappedBy = "categoriesList")
+  private List<Post> posts = new ArrayList<>();
 
   @Builder
-  public Categories(Post post, String name, Member member) {
-    this.post = post;
-    this.name = name;
-    this.member = member;
-  }
-  public Categories(String name) {
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
+  public Categories(String name) { this.name = name;}
   public static Categories createCategory(Post post, String name, Member member) {
-    return Categories.builder()
-            .post(post)
-            .name(name)
-            .member(member)
-            .build();
+    Categories category = new Categories(name);
+    category.getPosts().add(post);
+    post.getCategoriesList().add(category);
+    return category;
   }
 
 }

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
@@ -18,7 +19,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle, Pageable pageable);
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
-    //List<Post> findAllByMember(Member member);
     Page<Post> findByMemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
     Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
@@ -33,5 +33,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @EntityGraph(attributePaths = {"project"})
     List<Post> findByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(@Param("member") Member member, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT p.postId FROM Post p JOIN p.categoriesList c WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
+    List<Long> findPostIdsByCategoryName(@Param("categoryName") String categoryName);
+
+    Page<Post> findByPostIdIn(List<Long> postIds, Pageable pageable);
 }
 

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -155,12 +156,12 @@ public class PostCommandServiceImpl implements PostCommandService {
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
 
         // 카테고리 이름으로 Categories 엔티티를 생성하거나 조회
-        Set<Categories> categories = categoryNames.stream()
+        List<Categories> categories = categoryNames.stream()
                 .map(name -> {
                     // 카테고리 이름으로 Categories 엔티티를 조회하거나 새로 생성
                     return categoryCommandService.addCategory(post, name);
                 })
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         // 포스트에 카테고리를 설정
         post.setCategories(categories);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -10,15 +10,13 @@ import java.util.Optional;
 
 public interface PostQueryService {
 
-    //List<Post> findAllBySearch(Optional<String> optSearch);
-    //List<Post> getMemberPost(Long memberId);
     Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size);
+    Page<Post> getPostsByCategories(Optional<String> optSearch, int page, int size);
     Page<Post> getPostsByMember(Long memberId, int page, int size);
     Page<Post> getPostsByTeam(Long teamId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
     Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);
     Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size);
-
     Post.PostAdjacent findAdjacentPosts(Long postId);
 
     List<Post> getPostsByMonth(Long memberId, YearMonth yearMonth);

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -261,14 +261,23 @@ public class PostController {
     }
 
     // 카테고리명으로 다이어리 페이징 조회
-    @GetMapping("/category/paging")
+    @GetMapping("/categories/paging")
     @Operation(
-            summary = "카테고리명으로 다이어리 페이징 조회 API", description = "카테고리명으로 다이어리 페이징 조회합니다."
+            summary = "카테고리명으로 다이어리 페이징 조회 API", description = "카테고리명으로 다이어리를 페이징 조회합니다. Param으로 카테고리를 입력하세요."
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> findPostByCategory(
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByCategoryName(
+            @RequestParam Optional<String> search,
+            @RequestParam @Min(0) Integer page,
+            @RequestParam @Min(1) @Max(5) Integer size
     ){
-        return null;
+        log.info("Request to find posts by category with search keyword: {}", search.orElse("None"));
+        Page<Post> posts = postQueryService.getPostsByCategories(search, page, size);
+        log.info("Number of posts found: {}", posts.getTotalElements());
+        return ApiResponse.onSuccess(
+                SuccessStatus.POST_OK,
+                PostConverter.toPostPreviewListDTO(posts)
+        );
     }
 
     // 인접한 다이어리 조회 (특정 다이어리의 이전, 다음 다이어리 조회)


### PR DESCRIPTION
… Member 엔티티 수정

## #️⃣연관된 이슈
> #55

## 📝작업 내용
> - 카테고리명으로 다이어리 리스트 페이징 조회 기능 구현
> - Post, Categories, Member 엔티티 수정

## 🔎코드 설명 및 참고 사항
> - Post 엔티티에서 카테고리를 리스트로 변경
> - Categories, Member 엔티티에서 각각 Member, Categories 컬럼 제거

## 💬리뷰 요구사항
>
