### PR TITLE
Refactor: 다이어리 생성시 카테고리 설정을 하지 않도록 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -1,49 +1,34 @@
 package com.codiary.backend.global.converter;
 
-import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
 import com.codiary.backend.global.domain.entity.mapping.Categories;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
 import com.codiary.backend.global.web.dto.Post.PostResponseDTO;
 import org.springframework.data.domain.Page;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class PostConverter {
 
-//    private static List<String> convertCategoriesToCategoryNames(List<String> categories) {
-//        return categories.stream()
-//                .map(Categories::getName)
-//                .collect(Collectors.toList());
-//    }
-//
-//    private static Set<Categories> convertCategoryNamesToCategories(Set<String> categoryNames) {
-//        return categoryNames.stream()
-//                .map(Categories::new) // String을 받는 생성자를 사용
-//                .collect(Collectors.toSet());
-//    }
-
     public static Post toPost(PostRequestDTO.CreatePostRequestDTO request) {
-        List<Categories> categories = request.getPostCategory().stream()
-                .map(Categories::new) // Assuming Categories has a constructor that accepts String
-                .collect(Collectors.toList());
+//        List<Categories> categories = request.getPostCategory().stream()
+//                .map(Categories::new) // Assuming Categories has a constructor that accepts String
+//                .collect(Collectors.toList());
 
         return Post.builder()
                 .postTitle(request.getPostTitle())
                 .postBody(request.getPostBody())
                 .postStatus(request.getPostStatus())
-                .categoriesList(categories)
+                //.categoriesList(categories)
                 .postAccess(request.getPostAccess())
                 .build();
     }
 
     public static PostResponseDTO.CreatePostResultDTO toCreateResultDTO(Post post) {
-        List<String> postCategories = post.getCategoriesList().stream()
-                .map(Categories::getName)
-                .collect(Collectors.toList());
+//        List<String> postCategories = post.getCategoriesList().stream()
+//                .map(Categories::getName)
+//                .collect(Collectors.toList());
 
         return PostResponseDTO.CreatePostResultDTO.builder()
                 .postId(post.getPostId())
@@ -53,7 +38,7 @@ public class PostConverter {
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", postCategories))
+                //.postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -63,9 +48,9 @@ public class PostConverter {
     }
 
     public static PostResponseDTO.UpdatePostResultDTO toUpdatePostResultDTO(Post post) {
-        List<String> postCategories = post.getCategoriesList().stream()
-                .map(Categories::getName)
-                .collect(Collectors.toList());
+//        List<String> postCategories = post.getCategoriesList().stream()
+//                .map(Categories::getName)
+//                .collect(Collectors.toList());
 
         return PostResponseDTO.UpdatePostResultDTO.builder()
                 .postId(post.getPostId())
@@ -75,7 +60,7 @@ public class PostConverter {
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())
-                .postCategory(String.join(", ", postCategories))
+                //.postCategory(String.join(", ", postCategories))
                 .coauthorIds(post.getAuthorsList().stream()
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
@@ -356,6 +341,28 @@ public class PostConverter {
                 .hasLater(adjacent.getLaterPost() != null)
                 .olderPost(toPostAdjacentPreviewDTO(adjacent.getOlderPost()))
                 .laterPost(toPostAdjacentPreviewDTO(adjacent.getLaterPost()))
+                .build();
+    }
+
+
+    public static PostResponseDTO.UpdatePostResultDTO toSetPostCategoriesResultDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.UpdatePostResultDTO.builder()
+                .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
                 .build();
     }
 

--- a/src/main/java/com/codiary/backend/global/domain/entity/Post.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Post.java
@@ -82,10 +82,10 @@ public class Post extends BaseEntity {
     this.postTitle = request.getPostTitle();
     this.postBody = request.getPostBody();
     this.postAccess = request.getPostAccess();
-    List<Categories> categoryList = request.getPostCategory().stream()
-            .map(categoryName -> Categories.createCategory(this, categoryName, this.member))
-            .collect(Collectors.toList());
-    setCategories(categoryList);
+//    List<Categories> categoryList = request.getPostCategory().stream()
+//            .map(categoryName -> Categories.createCategory(this, categoryName, this.member))
+//            .collect(Collectors.toList());
+//    setCategories(categoryList);
     this.postStatus = request.getPostStatus();
   }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -35,7 +35,7 @@ public class PostController {
     // TODO: 현재 teamId=1로 되어 있는 부분 수정 구현 필요
     @PostMapping(consumes = "multipart/form-data")
     @Operation(
-            summary = "다이어리 생성 API", description = "다이어리를 생성합니다. 카테고리 설정은 다이어리 생성과는 별도로 설정해야 됩니다."
+            summary = "다이어리 생성 API", description = "다이어리를 생성합니다. **카테고리 설정은 다이어리 생성과는 별도로 설정해야 됩니다.**"
             //, security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.CreatePostResultDTO> createPost(
@@ -305,14 +305,14 @@ public class PostController {
             summary = "다이어리의 카테고리 설정 및 변경 API", description = "다이어리의 카테고리를 설정 및 변경합니다."
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setDiaryCategory(
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCategory(
             @PathVariable Long postId,
             @RequestBody Set<String> categoryNames
     ){
         Post updatedPost = postCommandService.setPostCategories(postId, categoryNames);
         return ApiResponse.onSuccess(
                 SuccessStatus.POST_OK,
-                PostConverter.toUpdatePostResultDTO(updatedPost)
+                PostConverter.toSetPostCategoriesResultDTO(updatedPost)
         );
     }
 
@@ -335,7 +335,7 @@ public class PostController {
             summary = "AI로 코드 실행 미리보기 API", description = "AI로 특정 글에 포함된 코드를 실행하여 미리보기 결과를 반환합니다."
             //, security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO> showDiaryCodePreview(
+    public ApiResponse<PostResponseDTO> showPostCodePreview(
     ){
         return null;
     }

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostRequestDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostRequestDTO.java
@@ -20,7 +20,7 @@ public class PostRequestDTO {
         private String postTitle;
         private String postBody;
         private Boolean postStatus;
-        private Set<String> postCategory;
+        //private Set<String> postCategory;
         private PostAccess postAccess;
         private List<MultipartFile> postFiles;
     }
@@ -33,7 +33,7 @@ public class PostRequestDTO {
         private String postTitle;
         private String postBody;
         private Boolean postStatus;
-        private Set<String> postCategory;
+        //private Set<String> postCategory;
         private PostAccess postAccess;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #63

## 📝작업 내용
> 다이어리 생성시 카테고리 설정을 하지 않도록 수정 

## 🔎코드 설명 및 참고 사항
> PostConverter에서 기존의 toUpdatePostResultDTO에서 postCategory를 반환하는 부분 제거 후, 카테고리 설정하는 컨트롤러에서 toSetPostCategoriesResultDTO를 통해 결과 가져오도록 수정

## 💬리뷰 요구사항
>
