### PR TITLE
Refactor: Post 리스트 조회시 다이어리 글에 포함된 이미지 url도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -15,7 +15,6 @@ public class PostConverter {
 //        List<Categories> categories = request.getPostCategory().stream()
 //                .map(Categories::new) // Assuming Categories has a constructor that accepts String
 //                .collect(Collectors.toList());
-
         return Post.builder()
                 .postTitle(request.getPostTitle())
                 .postBody(request.getPostBody())
@@ -29,7 +28,6 @@ public class PostConverter {
 //        List<String> postCategories = post.getCategoriesList().stream()
 //                .map(Categories::getName)
 //                .collect(Collectors.toList());
-
         return PostResponseDTO.CreatePostResultDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
@@ -65,6 +63,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .build();
     }
 
@@ -87,6 +86,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -127,6 +127,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -167,6 +168,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -208,6 +210,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -248,6 +251,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -288,6 +292,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -330,6 +335,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -363,6 +369,7 @@ public class PostConverter {
                         .map(author -> author.getMember().getMemberId())
                         .collect(Collectors.toSet()))
                 .postAccess(post.getPostAccess())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .build();
     }
 

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -64,9 +64,10 @@ public class PostResponseDTO {
         Boolean postStatus;
         String postCategory;
         Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
-        PostAccess postAccess;
     }
 
     @Getter
@@ -97,6 +98,7 @@ public class PostResponseDTO {
         String postCategory;
         Set<Long> coauthorIds;
         PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -130,6 +132,7 @@ public class PostResponseDTO {
         String postCategory;
         Set<Long> coauthorIds;
         PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -162,6 +165,7 @@ public class PostResponseDTO {
         String postCategory;
         Set<Long> coauthorIds;
         PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -194,6 +198,7 @@ public class PostResponseDTO {
         String postCategory;
         Set<Long> coauthorIds;
         PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -226,6 +231,7 @@ public class PostResponseDTO {
         String postCategory;
         Set<Long> coauthorIds;
         PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }
@@ -268,9 +274,10 @@ public class PostResponseDTO {
             Boolean postStatus;
             String postCategory;
             Set<Long> coauthorIds;
+            PostAccess postAccess;
+            PostFileResponseDTO.PostFileListDTO postFileList;
             LocalDateTime createdAt;
             LocalDateTime updatedAt;
-            PostAccess postAccess;
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #69

## 📝작업 내용
> Post 리스트 조회시 다이어리 글에 포함된 이미지 url도 함께 반환하도록 수정

## 🔎코드 설명 및 참고 사항
> Post 리스트 조회시 다이어리 글에 포함된 이미지 url도 함께 반환하도록 Post 관련 ResponseBody 및 Converter 수정

## 💬리뷰 요구사항
>
