### PR TITLE
Feat: 다이어리 관련 Api 멤버 토큰으로 접근 권한 설정

### DIFF
--- a/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.codiary.backend.global.config;
 
+import com.codiary.backend.global.jwt.EmailPasswordAuthenticationFilter;
 import com.codiary.backend.global.jwt.JwtAuthenticationFilter;
 import com.codiary.backend.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -28,23 +30,44 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable)
-                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/members/sign-up").permitAll()
-                        .requestMatchers("/members/login").permitAll()
-                        .requestMatchers("/**").permitAll()
-                        .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().authenticated()
+//        http
+//                .formLogin(AbstractHttpConfigurer::disable)
+//                .httpBasic(AbstractHttpConfigurer::disable)
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+//                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .authorizeHttpRequests(authorize -> authorize
+//                        .requestMatchers("/members/sign-up").permitAll()
+//                        .requestMatchers("/members/login").permitAll()
+//                        .requestMatchers("/posts").permitAll()//hasRole("USER")
+//                        .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+//                        .anyRequest().authenticated()
+//                )
+//                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+//
+//        return http.build();
+        return http
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf->csrf.disable())
+                .sessionManagement(session->session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .requestMatchers("/members/sign-up").permitAll()
+                                .requestMatchers("/members/login").permitAll()
+                                //.requestMatchers("/posts").hasRole("USER")
+                                .requestMatchers("/posts","/posts/{postId}", "/posts/visibility/{postId}", "/posts/team/{postId}", "/posts/coauthors/{postId}", "/posts/categories/{postId}", "/posts/team/{teamId}/member/{memberId}/paging", "/posts/project/{projectId}/team/{teamId}/paging", "/posts/project/{projectId}/member/{memberId}/paging", "/posts/member/{memberId}/paging").hasRole("USER")
+                                .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
-
-        return http.build();
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), EmailPasswordAuthenticationFilter.class).build();
     }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+        //return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
@@ -60,10 +83,4 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", config);
         return source;
     }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
 }

--- a/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
@@ -52,10 +52,13 @@ public class SecurityConfig {
                 .sessionManagement(session->session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
                         authorize -> authorize
+                                // Member 관련 접근
                                 .requestMatchers("/members/sign-up").permitAll()
                                 .requestMatchers("/members/login").permitAll()
-                                //.requestMatchers("/posts").hasRole("USER")
+                                // Post 관련 접근
                                 .requestMatchers("/posts","/posts/{postId}", "/posts/visibility/{postId}", "/posts/team/{postId}", "/posts/coauthors/{postId}", "/posts/categories/{postId}", "/posts/team/{teamId}/member/{memberId}/paging", "/posts/project/{projectId}/team/{teamId}/paging", "/posts/project/{projectId}/member/{memberId}/paging", "/posts/member/{memberId}/paging").hasRole("USER")
+                                .requestMatchers("/posts/title/paging", "/posts/categories/paging", "/posts/{postId}/adjacent").permitAll()
+                                // 기타 관련 접근
                                 .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/codiary/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/codiary/backend/global/config/SwaggerConfig.java
@@ -5,35 +5,35 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
     @Bean
-    public OpenAPI openAPI() {
+    public OpenAPI CodiaryAPI() {
+        Info info = new Info()
+                .title("Codiary Swagger")
+                .description("UMC-6th-Project Codiary Swagger")
+                .version("1.0.0");
 
         String jwtSchemeName = "JWT TOKEN";
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
         Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                        .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
-                        .scheme("bearer")
-                        .bearerFormat("JWT"));
+                .addSecuritySchemes("accessToken", new SecurityScheme()
+                        .name("Authorization")
+                        .type(SecurityScheme.Type.APIKEY) // HTTP 방식
+                        .in(SecurityScheme.In.HEADER)
+                        .bearerFormat("JWT")
+                );
 
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo())
+                .addServersItem(new Server().url("/"))
+                .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);
-    }
-
-    private Info apiInfo() {
-        return new Info()
-                .title("Codiary Swagger")
-                .description("UMC-6th-Project Codiary Swagger")
-                .version("1.0.0");
+                //.components(new Components())
+                //.addSecurityItem(securityRequirement)
     }
 }

--- a/src/main/java/com/codiary/backend/global/domain/entity/Post.java
+++ b/src/main/java/com/codiary/backend/global/domain/entity/Post.java
@@ -26,7 +26,7 @@ public class Post extends BaseEntity {
   private Long postId;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/codiary/backend/global/jwt/EmailPasswordAuthenticationFilter.java
+++ b/src/main/java/com/codiary/backend/global/jwt/EmailPasswordAuthenticationFilter.java
@@ -1,0 +1,26 @@
+package com.codiary.backend.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class EmailPasswordAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    public EmailPasswordAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super.setAuthenticationManager(authenticationManager);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);
+        setDetails(request, authRequest);
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/src/main/java/com/codiary/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codiary/backend/global/jwt/JwtAuthenticationFilter.java
@@ -2,37 +2,53 @@ package com.codiary.backend.global.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
+public class JwtAuthenticationFilter extends GenericFilterBean {
+// extends OncePerRequestFilter
     public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String BEARER_PREFIX = "Bearer";
 
     private final JwtTokenProvider jwtTokenProvider;
 
+//    @Override
+//    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+//
+//        // 1. 요청에서 토큰 추출
+//        String token = resolveToken(request);
+//
+//        // 2. 토큰 유효성 검사
+//        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+//            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+//            SecurityContextHolder.getContext().setAuthentication(authentication);
+//        }
+//
+//        filterChain.doFilter(request, response);
+//    }
     @Override
-    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // 1. Request Header에서 JWT 토큰 추출
+        String token = resolveToken((HttpServletRequest) request);
 
-        // 1. 요청에서 토큰 추출
-        String token = resolveToken(request);
-
-        // 2. 토큰 유효성 검사
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+        // 2. validateToken으로 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-
-        filterChain.doFilter(request, response);
+        chain.doFilter(request, response);
     }
 
     // Request Header 에서 토큰 정보 추출

--- a/src/main/java/com/codiary/backend/global/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/MemberService/MemberCommandServiceImpl.java
@@ -84,12 +84,12 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                     .authenticate(authenticationToken);
 
             // 3. 인증 정보를 기반으로 JWT 토큰 생성
-            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
-            Member member = memberRepository.findByEmail(loginRequest.getEmail()).orElseThrow();
+            Member getMember = memberRepository.findByEmail(loginRequest.getEmail()).orElseThrow();
+            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication, getMember.getMemberId());
 
             return ApiResponse.of(SuccessStatus.MEMBER_OK, MemberResponseDTO.MemberTokenResponseDTO.builder()
-                    .email(member.getEmail())
-                    .nickname(member.getNickname())
+                    .email(getMember.getEmail())
+                    .nickname(getMember.getNickname())
                     .tokenInfo(tokenInfo)
                     .build());
         } catch (AuthenticationException e) {

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -8,7 +8,7 @@ import java.util.Set;
 public interface PostCommandService {
 
     // 포스트 생성
-    Post createPost(Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request);
+    Post createPost(PostRequestDTO.CreatePostRequestDTO request);
     //포스트 수정
     Post updatePost(Long memberId, Long postId, PostRequestDTO.UpdatePostDTO request);
     //포스트 삭제

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -16,7 +16,7 @@ public interface PostCommandService {
     // 공개/비공개 설정
     Post updateVisibility(Long postId, PostRequestDTO.UpdateVisibilityRequestDTO request);
     // 공동 저자 설정
-    Post updateCoauthors(Long postId, Long memberId, PostRequestDTO.UpdateCoauthorRequestDTO request);
+    Post updateCoauthors(Long postId, PostRequestDTO.UpdateCoauthorRequestDTO request);
     // 글 소속 팀 설정
     Post setPostTeam(Long postId, Long memberId, Long teamId);
 

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -18,7 +18,7 @@ public interface PostCommandService {
     // 공동 저자 설정
     Post updateCoauthors(Long postId, PostRequestDTO.UpdateCoauthorRequestDTO request);
     // 글 소속 팀 설정
-    Post setPostTeam(Long postId, Long memberId, Long teamId);
+    Post setPostTeam(Long postId, Long teamId);
 
     Post setPostCategories(Long postId, Set<String> categories);
 

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -8,7 +8,7 @@ import java.util.Set;
 public interface PostCommandService {
 
     // 포스트 생성
-    Post createPost(Long memberId, Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request);
+    Post createPost(Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request);
     //포스트 수정
     Post updatePost(Long memberId, Long postId, PostRequestDTO.UpdatePostDTO request);
     //포스트 삭제

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -14,7 +14,7 @@ public interface PostCommandService {
     //포스트 삭제
     void deletePost(Long postId);
     // 공개/비공개 설정
-    Post updateVisibility(Long postId, Long memberId, PostRequestDTO.UpdateVisibilityRequestDTO request);
+    Post updateVisibility(Long postId, PostRequestDTO.UpdateVisibilityRequestDTO request);
     // 공동 저자 설정
     Post updateCoauthors(Long postId, Long memberId, PostRequestDTO.UpdateCoauthorRequestDTO request);
     // 글 소속 팀 설정

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -12,7 +12,7 @@ public interface PostCommandService {
     //포스트 수정
     Post updatePost(Long postId, PostRequestDTO.UpdatePostDTO request);
     //포스트 삭제
-    void deletePost(Long memberId, Long postId);
+    void deletePost(Long postId);
     // 공개/비공개 설정
     Post updateVisibility(Long postId, Long memberId, PostRequestDTO.UpdateVisibilityRequestDTO request);
     // 공동 저자 설정

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -14,11 +14,11 @@ public interface PostCommandService {
     //포스트 삭제
     void deletePost(Long memberId, Long postId);
     // 공개/비공개 설정
-    Post updateVisibility(Long postId, PostRequestDTO.UpdateVisibilityRequestDTO request);
+    Post updateVisibility(Long postId, Long memberId, PostRequestDTO.UpdateVisibilityRequestDTO request);
     // 공동 저자 설정
-    Post updateCoauthors(Long postId, PostRequestDTO.UpdateCoauthorRequestDTO request);
+    Post updateCoauthors(Long postId, Long memberId, PostRequestDTO.UpdateCoauthorRequestDTO request);
     // 글 소속 팀 설정
-    Post setPostTeam(Long postId, Long teamId);
+    Post setPostTeam(Long postId, Long memberId, Long teamId);
 
     Post setPostCategories(Long postId, Set<String> categories);
 

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandService.java
@@ -10,7 +10,7 @@ public interface PostCommandService {
     // 포스트 생성
     Post createPost(PostRequestDTO.CreatePostRequestDTO request);
     //포스트 수정
-    Post updatePost(Long memberId, Long postId, PostRequestDTO.UpdatePostDTO request);
+    Post updatePost(Long postId, PostRequestDTO.UpdatePostDTO request);
     //포스트 삭제
     void deletePost(Long memberId, Long postId);
     // 공개/비공개 설정

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -129,10 +129,10 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public Post setPostTeam(Long postId, Long memberId, Long teamId) {
+    public Post setPostTeam(Long postId, Long teamId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
-        Member getMember = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found"));

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -48,7 +48,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     private final PostFileRepository postFileRepository; // 추가
 
     @Override
-    public Post createPost(Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request) {
+    public Post createPost(PostRequestDTO.CreatePostRequestDTO request) {
 
         Post newPost = PostConverter.toPost(request);
 
@@ -56,15 +56,15 @@ public class PostCommandServiceImpl implements PostCommandService {
         //        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
         Member getMember = memberCommandService.getRequester();
 
-        Team getTeam = teamRepository.findById(teamId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found"));
-
-        Project getProject = projectRepository.findById(projectId)
-                .orElseThrow(() -> new IllegalArgumentException("Project not found"));
+//        Team getTeam = teamRepository.findById(teamId)
+//                .orElseThrow(() -> new IllegalArgumentException("Team not found"));
+//
+//        Project getProject = projectRepository.findById(projectId)
+//                .orElseThrow(() -> new IllegalArgumentException("Project not found"));
 
         newPost.setMember(getMember);
-        newPost.setTeam(getTeam);
-        newPost.setProject(getProject);
+        //newPost.setTeam(getTeam);
+        //newPost.setProject(getProject);
 
         Post tempPost = postRepository.save(newPost);
         tempPost.setPostFileList(new ArrayList<>());

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -107,10 +107,10 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public Post updateCoauthors(Long postId, Long memberId, PostRequestDTO.UpdateCoauthorRequestDTO request) {
+    public Post updateCoauthors(Long postId, PostRequestDTO.UpdateCoauthorRequestDTO request) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
-        Member getMember = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         // 기존 공동 저자 리스트 삭제
         post.getAuthorsList().clear();

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -80,7 +80,6 @@ public class PostCommandServiceImpl implements PostCommandService {
 
     @Override
     public Post updatePost(Long postId, PostRequestDTO.UpdatePostDTO request) {
-        //Member getMember = memberRepository.findById(memberId).get();
         Member getMember = memberCommandService.getRequester();
         Post updatePost = postRepository.findById(postId).get();
         updatePost.update(request);
@@ -89,8 +88,8 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public void deletePost(Long memberId, Long postId) {
-        Member getMember = memberRepository.findById(memberId).get();
+    public void deletePost(Long postId) {
+        Member getMember = memberCommandService.getRequester();
 
         Post deletePost = postRepository.findById(postId).get();
         postRepository.delete(deletePost);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -51,20 +51,9 @@ public class PostCommandServiceImpl implements PostCommandService {
     public Post createPost(PostRequestDTO.CreatePostRequestDTO request) {
 
         Post newPost = PostConverter.toPost(request);
-
-        //Member getMember = memberRepository.findById(memberId)
-        //        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
         Member getMember = memberCommandService.getRequester();
 
-//        Team getTeam = teamRepository.findById(teamId)
-//                .orElseThrow(() -> new IllegalArgumentException("Team not found"));
-//
-//        Project getProject = projectRepository.findById(projectId)
-//                .orElseThrow(() -> new IllegalArgumentException("Project not found"));
-
         newPost.setMember(getMember);
-        //newPost.setTeam(getTeam);
-        //newPost.setProject(getProject);
 
         Post tempPost = postRepository.save(newPost);
         tempPost.setPostFileList(new ArrayList<>());
@@ -74,7 +63,6 @@ public class PostCommandServiceImpl implements PostCommandService {
                 if (file.isEmpty()) {
                     continue;
                 }
-
                 String uuid = UUID.randomUUID().toString();
                 Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
                 String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), file);
@@ -91,9 +79,9 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public Post updatePost(Long memberId, Long postId, PostRequestDTO.UpdatePostDTO request) {
-        Member getMember = memberRepository.findById(memberId).get();
-
+    public Post updatePost(Long postId, PostRequestDTO.UpdatePostDTO request) {
+        //Member getMember = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
         Post updatePost = postRepository.findById(postId).get();
         updatePost.update(request);
 

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -17,6 +17,7 @@ import com.codiary.backend.global.repository.PostRepository;
 import com.codiary.backend.global.repository.ProjectRepository;
 import com.codiary.backend.global.repository.TeamRepository;
 import com.codiary.backend.global.service.CategoryService.CategoryCommandService;
+import com.codiary.backend.global.service.MemberService.MemberCommandService;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,17 +42,19 @@ public class PostCommandServiceImpl implements PostCommandService {
     private final TeamRepository teamRepository;
     private final ProjectRepository projectRepository;
     private final CategoryCommandService categoryCommandService;
+    private final MemberCommandService memberCommandService;
     private final AmazonS3Manager s3Manager; // 추가
     private final UuidRepository uuidRepository; // 추가
     private final PostFileRepository postFileRepository; // 추가
 
     @Override
-    public Post createPost(Long memberId, Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request) {
+    public Post createPost(Long teamId, Long projectId, PostRequestDTO.CreatePostRequestDTO request) {
 
         Post newPost = PostConverter.toPost(request);
 
-        Member getMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        //Member getMember = memberRepository.findById(memberId)
+        //        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        Member getMember = memberCommandService.getRequester();
 
         Team getTeam = teamRepository.findById(teamId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found"));

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostCommandServiceImpl.java
@@ -97,10 +97,10 @@ public class PostCommandServiceImpl implements PostCommandService {
 
 
     @Override
-    public Post updateVisibility(Long postId, Long memberId, PostRequestDTO.UpdateVisibilityRequestDTO request) {
+    public Post updateVisibility(Long postId, PostRequestDTO.UpdateVisibilityRequestDTO request) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
-        Member getMember = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         post.setPostStatus(request.getPostStatus());
         return postRepository.save(post);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -13,7 +13,7 @@ public interface PostQueryService {
     Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size);
     Page<Post> getPostsByCategories(Optional<String> optSearch, int page, int size);
     Page<Post> getPostsByMember(Long memberId, int page, int size);
-    Page<Post> getPostsByTeam(Long teamId, int page, int size);
+    Page<Post> getPostsByTeam(Long teamId, Long memberId, int page, int size);
     Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
     Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);
     Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryService.java
@@ -12,11 +12,11 @@ public interface PostQueryService {
 
     Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size);
     Page<Post> getPostsByCategories(Optional<String> optSearch, int page, int size);
-    Page<Post> getPostsByMember(Long memberId, int page, int size);
-    Page<Post> getPostsByTeam(Long teamId, Long memberId, int page, int size);
-    Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size);
+    Page<Post> getPostsByMember(int page, int size);
+    Page<Post> getPostsByTeam(Long teamId, int page, int size);
+    Page<Post> getPostsByMemberInProject(Long projectId, int page, int size);
     Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size);
-    Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size);
+    Page<Post> getPostsByMemberInTeam(Long teamId, int page, int size);
     Post.PostAdjacent findAdjacentPosts(Long postId);
 
     List<Post> getPostsByMonth(Long memberId, YearMonth yearMonth);

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -11,6 +11,7 @@ import com.codiary.backend.global.repository.MemberRepository;
 import com.codiary.backend.global.repository.PostRepository;
 import com.codiary.backend.global.repository.ProjectRepository;
 import com.codiary.backend.global.repository.TeamRepository;
+import com.codiary.backend.global.service.MemberService.MemberCommandService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final TeamRepository teamRepository;
     private final PostRepository postRepository;
     private final ProjectRepository projectRepository;
+    private final MemberCommandService memberCommandService;
 
     @Override
     public Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size) {
@@ -67,21 +69,21 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public Page<Post> getPostsByMember(Long memberId, int page, int size) {
+    public Page<Post> getPostsByMember(int page, int size) {
         PageRequest request = PageRequest.of(page, size);
-        Member member = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
-        if (!postRepository.existsByMember(member)){
+        if (!postRepository.existsByMember(getMember)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
         }
-        return postRepository.findByMemberOrderByCreatedAtDescPostIdDesc(member, request);
+        return postRepository.findByMemberOrderByCreatedAtDescPostIdDesc(getMember, request);
     }
 
     @Override
-    public Page<Post> getPostsByTeam(Long teamId, Long memberId, int page, int size) {
+    public Page<Post> getPostsByTeam(Long teamId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
         Team team = teamRepository.findById(teamId).get();
-        Member member = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         if (!postRepository.existsByTeam(team)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
@@ -90,18 +92,18 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size) {
+    public Page<Post> getPostsByMemberInProject(Long projectId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
         Project project = projectRepository.findById(projectId).get();
-        Member member = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         if (!postRepository.existsByProject(project)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_PROJECT);
         }
-        if (!postRepository.existsByMember(member)){
+        if (!postRepository.existsByMember(getMember)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
         }
-        return postRepository.findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(project, member, request);
+        return postRepository.findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(project, getMember, request);
     }
 
     @Override
@@ -120,18 +122,18 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size) {
+    public Page<Post> getPostsByMemberInTeam(Long teamId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
         Team team = teamRepository.findById(teamId).get();
-        Member member = memberRepository.findById(memberId).get();
+        Member getMember = memberCommandService.getRequester();
 
         if (!postRepository.existsByTeam(team)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
         }
-        if (!postRepository.existsByMember(member)){
+        if (!postRepository.existsByMember(getMember)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
         }
-        return postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, member, request);
+        return postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, getMember, request);
     }
 
     @Override

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -88,7 +88,18 @@ public class PostQueryServiceImpl implements PostQueryService {
         if (!postRepository.existsByTeam(team)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
         }
-        return postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
+        if (!postRepository.existsByMember(getMember)){
+            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
+        }
+
+        Page<Post> posts = postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
+
+        for (Post post : posts) {
+            if (post.getMember() == null) {
+                throw new IllegalStateException("Post has null member");
+            }
+        }
+        return posts;
     }
 
     @Override

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -78,9 +78,10 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public Page<Post> getPostsByTeam(Long teamId, int page, int size) {
+    public Page<Post> getPostsByTeam(Long teamId, Long memberId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
         Team team = teamRepository.findById(teamId).get();
+        Member member = memberRepository.findById(memberId).get();
 
         if (!postRepository.existsByTeam(team)){
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -75,14 +75,15 @@ public class PostController {
     // 다이어리 삭제하기
     @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{postId}")
-    @Operation(summary = "다이어리 삭제 API", description = "다이어리를 삭제합니다. Param으로 memberId를 입력하세요"
+    @Operation(summary = "다이어리 삭제 API", description = "다이어리를 삭제합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<?> deletePost(@RequestParam Long memberId, @PathVariable Long postId){
+    public ApiResponse<?> deletePost(@PathVariable Long postId){
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
-        postCommandService.deletePost(memberId, postId);
+        postCommandService.deletePost(postId);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, null);
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -126,11 +126,12 @@ public class PostController {
     @Operation(summary = "다이어리의 소속 팀 설정 API", description = "다이어리의 소속 팀을 설정합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostTeam(@PathVariable Long postId, Long memberId, @RequestBody PostRequestDTO.SetTeamRequestDTO request) {
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostTeam(@PathVariable Long postId, @RequestBody PostRequestDTO.SetTeamRequestDTO request) {
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
-        Post updatedPost = postCommandService.setPostTeam(postId, memberId, request.getTeamId());
+        Post updatedPost = postCommandService.setPostTeam(postId, request.getTeamId());
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost)
         );
     }
@@ -143,11 +144,13 @@ public class PostController {
     @Operation(summary = "저자의 다이어리 리스트 페이징 조회 API", description = "저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.MemberPostPreviewListDTO> findPostByMember(@PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size) {
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+    public ApiResponse<PostResponseDTO.MemberPostPreviewListDTO> findPostByMember(@RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size) {
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
         //List<Post> memberPostList = postQueryService.getMemberPost(memberId);
-        Page<Post> posts = postQueryService.getPostsByMember(memberId, page, size);
+        Page<Post> posts = postQueryService.getPostsByMember(page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostPreviewListDTO(posts));
     }
 
@@ -158,10 +161,12 @@ public class PostController {
     @Operation(summary = "팀의 다이어리 리스트 페이징 조회 API", description = "팀의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.TeamPostPreviewListDTO> findPostByTeam(@PathVariable Long teamId, @RequestParam Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
-        Page<Post> posts = postQueryService.getPostsByTeam(teamId, memberId, page, size);
+    public ApiResponse<PostResponseDTO.TeamPostPreviewListDTO> findPostByTeam(@PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Page<Post> posts = postQueryService.getPostsByTeam(teamId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toTeamPostPreviewListDTO(posts));
     }
 
@@ -172,10 +177,12 @@ public class PostController {
     @Operation(summary = "프로젝트별 저자의 다이어리 리스트 페이징 조회 API", description = "프로젝트별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
-        Page<Post> posts = postQueryService.getPostsByMemberInProject(projectId, memberId, page, size);
+    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Page<Post> posts = postQueryService.getPostsByMemberInProject(projectId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostInProjectPreviewListDTO(posts));
     }
 
@@ -186,9 +193,11 @@ public class PostController {
     @Operation(summary = "프로젝트별 팀의 다이어리 리스트 페이징 조회 API", description = "프로젝트별 팀의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.TeamPostInProjectPreviewListDTO> findPostByTeamInProject(@PathVariable Long projectId, @PathVariable Long teamId, @RequestParam Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+    public ApiResponse<PostResponseDTO.TeamPostInProjectPreviewListDTO> findPostByTeamInProject(@PathVariable Long projectId, @PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
         Page<Post> posts = postQueryService.getPostsByTeamInProject(projectId, teamId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toTeamPostInProjectPreviewListDTO(posts));
     }
@@ -200,10 +209,12 @@ public class PostController {
     @Operation(summary = "팀별 저자의 다이어리 리스트 페이징 조회 API", description = "팀별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.MemberPostInTeamPreviewListDTO> findPostByMemberInTeam(@PathVariable Long teamId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
-        Page<Post> posts = postQueryService.getPostsByMemberInTeam(teamId, memberId, page, size);
+    public ApiResponse<PostResponseDTO.MemberPostInTeamPreviewListDTO> findPostByMemberInTeam(@PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Page<Post> posts = postQueryService.getPostsByMemberInTeam(teamId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostInTeamPreviewListDTO(posts));
     }
 
@@ -246,9 +257,10 @@ public class PostController {
     @Operation(summary = "다이어리의 카테고리 설정 및 변경 API", description = "다이어리의 카테고리를 설정 및 변경합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCategory(@PathVariable Long postId, @RequestParam Long memberId, @RequestBody Set<String> categoryNames){
-        // 토큰 유효성 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCategory(@PathVariable Long postId, @RequestBody Set<String> categoryNames){
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
         Post updatedPost = postCommandService.setPostCategories(postId, categoryNames);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toSetPostCategoriesResultDTO(updatedPost));
     }

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -50,9 +50,9 @@ public class PostController {
         // 토큰 유효설 검사 (memberId)
         jwtTokenProvider.isValidToken(member.getMemberId());
 
-        Long teamId = 1L;
-        Long projectId = 1L;
-        Post newPost = postCommandService.createPost(teamId, projectId, request);
+        //Long teamId = 1L;
+        //Long projectId = 1L;
+        Post newPost = postCommandService.createPost(request);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toCreateResultDTO(newPost));
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -60,14 +60,15 @@ public class PostController {
     // 멤버의 다이어리 수정하기
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{postId}")
-    @Operation(summary = "다이어리 수정 API", description = "다이어리를 수정합니다. Param으로 memberId를 입력하세요"
+    @Operation(summary = "다이어리 수정 API", description = "다이어리를 수정합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> updatePost(@RequestParam Long memberId, @RequestBody PostRequestDTO.UpdatePostDTO request, @PathVariable Long postId){
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> updatePost(@RequestBody PostRequestDTO.UpdatePostDTO request, @PathVariable Long postId){
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
-        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(postCommandService.updatePost(memberId, postId, request)));
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(postCommandService.updatePost(postId, request)));
     }
 
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -110,11 +110,12 @@ public class PostController {
     @Operation(summary = "다이어리 공동 저자 설정 API", description = "다이어리의 공동 저자를 설정합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCoauthor(@PathVariable Long postId, @RequestParam Long memberId, @RequestBody PostRequestDTO.UpdateCoauthorRequestDTO request) {
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCoauthor(@PathVariable Long postId, @RequestBody PostRequestDTO.UpdateCoauthorRequestDTO request) {
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
-        Post updatedPost = postCommandService.updateCoauthors(postId, memberId, request);
+        Post updatedPost = postCommandService.updateCoauthors(postId, request);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost));
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -91,14 +91,15 @@ public class PostController {
     // 다이어리 공개/비공개 설정
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("/visibility/{postId}")
-    @Operation(summary = "다이어리 공개/비공개 설정 API", description = "다이어리의 공개 범위를 설정합니다. Param으로 memberId를 입력하세요"
+    @Operation(summary = "다이어리 공개/비공개 설정 API", description = "다이어리의 공개 범위를 설정합니다."
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostVisibility(@PathVariable Long postId, @RequestParam Long memberId, @RequestBody PostRequestDTO.UpdateVisibilityRequestDTO request) {
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostVisibility(@PathVariable Long postId, @RequestBody PostRequestDTO.UpdateVisibilityRequestDTO request) {
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
-        Post updatedPost = postCommandService.updateVisibility(postId, memberId, request);
+        Post updatedPost = postCommandService.updateVisibility(postId, request);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost));
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -3,8 +3,10 @@ package com.codiary.backend.global.web.controller;
 import com.codiary.backend.global.apiPayload.ApiResponse;
 import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
 import com.codiary.backend.global.converter.PostConverter;
+import com.codiary.backend.global.domain.entity.Member;
 import com.codiary.backend.global.domain.entity.Post;
 import com.codiary.backend.global.jwt.JwtTokenProvider;
+import com.codiary.backend.global.service.MemberService.MemberCommandService;
 import com.codiary.backend.global.service.PostService.PostCommandService;
 import com.codiary.backend.global.service.PostService.PostQueryService;
 import com.codiary.backend.global.web.dto.Post.PostRequestDTO;
@@ -33,6 +35,7 @@ import java.util.Set;
 public class PostController {
     private final PostCommandService postCommandService;
     private final PostQueryService postQueryService;
+    private final MemberCommandService memberCommandService;
     private final JwtTokenProvider jwtTokenProvider;
 
     // 다이어리 생성하기
@@ -42,13 +45,14 @@ public class PostController {
     @Operation(summary = "다이어리 생성 API", description = "다이어리를 생성합니다. **카테고리 설정은 다이어리 생성과는 별도로 설정해야 됩니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
-    public ApiResponse<PostResponseDTO.CreatePostResultDTO> createPost(@RequestParam Long memberId, @ModelAttribute PostRequestDTO.CreatePostRequestDTO request) {
+    public ApiResponse<PostResponseDTO.CreatePostResultDTO> createPost(@ModelAttribute PostRequestDTO.CreatePostRequestDTO request) {
+        Member member = memberCommandService.getRequester();
         // 토큰 유효설 검사 (memberId)
-        jwtTokenProvider.isValidToken(memberId);
+        jwtTokenProvider.isValidToken(member.getMemberId());
 
         Long teamId = 1L;
         Long projectId = 1L;
-        Post newPost = postCommandService.createPost(memberId, teamId, projectId, request);
+        Post newPost = postCommandService.createPost(teamId, projectId, request);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toCreateResultDTO(newPost));
     }
 

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -141,7 +141,7 @@ public class PostController {
     @PreAuthorize("hasRole('USER')")
     // TODO: 멤버별 작성한 글 조회시 공동 저자로 등록된 멤버도 조회가능하도록 기능 수정 필요
     @GetMapping("/member/{memberId}/paging")
-    @Operation(summary = "저자의 다이어리 리스트 페이징 조회 API", description = "저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
+    @Operation(summary = "저자의 다이어리 리스트 페이징 조회 API", description = "저자의 다이어리 리스트를 페이징으로 조회합니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.MemberPostPreviewListDTO> findPostByMember(@RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size) {
@@ -174,7 +174,7 @@ public class PostController {
     // 프로젝트별 저자의 다이어리 리스트 페이징 조회
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/project/{projectId}/member/{memberId}/paging")
-    @Operation(summary = "프로젝트별 저자의 다이어리 리스트 페이징 조회 API", description = "프로젝트별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
+    @Operation(summary = "프로젝트별 저자의 다이어리 리스트 페이징 조회 API", description = "프로젝트별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
@@ -206,7 +206,7 @@ public class PostController {
     // 팀별 저자의 다이어리 리스트 페이징 조회
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/team/{teamId}/member/{memberId}/paging")
-    @Operation(summary = "팀별 저자의 다이어리 리스트 페이징 조회 API", description = "팀별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**"
+    @Operation(summary = "팀별 저자의 다이어리 리스트 페이징 조회 API", description = "팀별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**"
             , security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.MemberPostInTeamPreviewListDTO> findPostByMemberInTeam(@PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
@@ -231,12 +231,17 @@ public class PostController {
 
 
     // 카테고리명으로 다이어리 리스트 페이징 조회
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/categories/paging")
     @Operation(summary = "카테고리명으로 다이어리 리스트 페이징 조회 API", description = "카테고리명으로 다이어리 리스트를 페이징 조회합니다. 입력한 카테고리가 포함된 모든 다이어리를 조회할 수 있습니다. Param으로 카테고리를 입력하세요."
-            //, security = @SecurityRequirement(name = "accessToken")
+            , security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByCategoryName(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
-        Page<Post> posts = postQueryService.getPostsByCategories(search, page, size);
+        Member member = memberCommandService.getRequester();
+        // 토큰 유효설 검사 (memberId)
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Page<Post> posts = postQueryService.getPostsByCategories(Optional.of(search.orElse("")), page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostPreviewListDTO(posts));
     }
 
@@ -244,7 +249,7 @@ public class PostController {
     // 인접한 다이어리 조회 (특정 다이어리의 이전, 다음 다이어리 조회)
     @GetMapping("/{postId}/adjacent")
     @Operation(summary = "인접한 다이어리 조회 API", description = "특정 다이어리의 인접한 다이어리를 조회합니다."
-            //, security = @SecurityRequirement(name = "accessToken")
+            , security = @SecurityRequirement(name = "accessToken")
     )
     public ApiResponse<PostResponseDTO.PostAdjacentDTO> findAdjacentPosts(@PathVariable Long postId){
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostAdjacentDTO(postQueryService.findAdjacentPosts(postId)));


### PR DESCRIPTION
## #️⃣연관된 이슈
> #85

## 📝작업 내용
> 멤버 토큰으로 다이어리 관련 Api 접근 가능하도록 설정
- 다이어리 생성, 수정, 삭제 기능 멤버 토큰 필요
- 다이어리 공개/비공개 설정, 공동저자 설정, 소속 팀 설정,  카테고리 설정 기능 멤버 토큰 필요
- 저자의 다이어리 조회, 팀의 다이어리 조회, 프로젝트별 저자의 다이어리 조회, 프로젝트별 팀의 다이어리 조회, 팀별 저자의 다이어리 조회 기능 멤버 토큰 필요
- 제목으로 다이어리 조회, 카테고리명으로 다이어리 조회, 인접한 다이어리 조회는 멤버 토큰 필요 X

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
