### PR TITLE
Fix: 다이어리 조회시 teamId 또는 projectId 값이 null이어도 정상 조회되도록 postConverter 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -198,7 +198,7 @@ public class PostConverter {
                 .collect(Collectors.toList());
 
         return PostResponseDTO.MemberPostInProjectPreviewDTO.builder()
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
@@ -239,8 +239,8 @@ public class PostConverter {
                 .collect(Collectors.toList());
 
         return PostResponseDTO.TeamPostInProjectPreviewDTO.builder()
-                .projectId(post.getProject().getProjectId())
-                .teamId(post.getTeam().getTeamId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
                 .postTitle(post.getPostTitle())
@@ -280,10 +280,10 @@ public class PostConverter {
                 .collect(Collectors.toList());
 
         return PostResponseDTO.MemberPostInTeamPreviewDTO.builder()
-                .teamId(post.getTeam().getTeamId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .memberId(post.getMember().getMemberId())
                 .postId(post.getPostId())
-                .projectId(post.getProject().getProjectId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())
                 .postBody(post.getPostBody())
                 .postStatus(post.getPostStatus())

--- a/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/codiary/backend/global/service/PostService/PostQueryServiceImpl.java
@@ -85,9 +85,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         PageRequest request = PageRequest.of(page, size);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
-        // 멤버가 작성한 다이어리 조회
         Page<Post> postsByMember = postRepository.findByMemberOrderByCreatedAtDescPostIdDesc(member, request);
-        // 멤버가 공동 저자인 다이어리 조회
         Page<Post> postsByCoauthor = postRepository.findByAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(member, request);
 
         if (postsByMember.isEmpty() && postsByCoauthor.isEmpty()) {
@@ -97,7 +95,6 @@ public class PostQueryServiceImpl implements PostQueryService {
         List<Post> combinedPosts = new ArrayList<>();
         combinedPosts.addAll(postsByMember.getContent());
         combinedPosts.addAll(postsByCoauthor.getContent());
-        // 병합된 리스트를 페이지로 반환
         return new PageImpl<>(combinedPosts, request, combinedPosts.size());
     }
 
@@ -143,20 +140,37 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postRepository.findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(project, team, request);
     }
 
+//    @Override
+//    public Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size) {
+//        PageRequest request = PageRequest.of(page, size);
+//        Team team = teamRepository.findById(teamId).get();
+//        Member member = memberRepository.findById(memberId).get();
+//
+//        if (!postRepository.existsByTeam(team)){
+//            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
+//        }
+//        if (!postRepository.existsByMember(member)){
+//            throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
+//        }
+//        return postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, member, request);
+//    }
+
     @Override
     public Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
-        Team team = teamRepository.findById(teamId).get();
-        Member member = memberRepository.findById(memberId).get();
-
-        if (!postRepository.existsByTeam(team)){
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.TEAM_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (!postRepository.existsByTeam(team)) {
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM);
         }
-        if (!postRepository.existsByMember(member)){
+        if (!postRepository.existsByMember(member)) {
             throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER);
         }
         return postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, member, request);
     }
+
 
     @Override
     public Post.PostAdjacent findAdjacentPosts(Long postId) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #119

## 📝작업 내용
> 다이어리 조회시 teamId 또는 projectId 값이 null이어도 정상 조회되도록 postConverter 수정

## 🔎코드 설명 및 참고 사항
> 다이어리 조회시 teamId 또는 projectId 값이 null이어도 정상 조회되도록 postConverter 수정

## 💬리뷰 요구사항
>
