### PR TITLE
Refactor: 프로젝트별 저자의 다이어리 페이징 조회, 팀별 저자의 다이어리 페이징 조회 기능에서도 공동저자로 설정된 다이어리도 함께 조회되도록 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -61,7 +61,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // 카테고리 관련 에러 7000
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY_7001", "카테고리가 없습니다."),
     // 회원별 관심 카테고리 관련 에러 8000
-    MEMBERCATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERCATEGORY_8001", "회원별 관심 카테고리가 없습니다.")
+    MEMBERCATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERCATEGORY_8001", "회원별 관심 카테고리가 없습니다."),
+
+    // 프로젝트 관련 에러 9000
+    PROJECT_NOT_FOUND(HttpStatus.BAD_REQUEST, "PROJECT_3009", "프로젝트가 없습니다.")
+
+
     ;
 
 

--- a/src/main/java/com/codiary/backend/global/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/global/repository/PostRepository.java
@@ -15,26 +15,18 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-
     Page<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle, Pageable pageable);
-
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
-
     Page<Post> findByMemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
-
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
-
     Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
-
     Page<Post> findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(Project project, Team team, Pageable pageable);
-
     Page<Post> findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(Team team, Member member, Pageable pageable);
-
     Page<Post> findByAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
+    Page<Post> findByProjectAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
+    Page<Post> findByTeamAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Team team, Member member, Pageable pageable);
     boolean existsByTeam(Team team);
-
     boolean existsByProject(Project project);
-
     boolean existsByMember(Member member);
 
     Optional<Post> findTopByPostIdLessThanOrderByCreatedAtDescPostIdDesc(Long postId);

--- a/src/main/java/com/codiary/backend/global/web/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/global/web/controller/PostController.java
@@ -133,7 +133,7 @@ public class PostController {
     // 프로젝트별 저자의 다이어리 리스트 페이징 조회
     @GetMapping("/project/{projectId}/member/{memberId}/paging")
     @Operation(summary = "프로젝트별 저자의 다이어리 리스트 페이징 조회 API", description = "프로젝트별 저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
-    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(6) Integer size){
+    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
         Page<Post> posts = postQueryService.getPostsByMemberInProject(projectId, memberId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostInProjectPreviewListDTO(posts));
     }
@@ -160,7 +160,7 @@ public class PostController {
     // 제목으로 다이어리 리스트 페이징 조회
     @GetMapping("/title/paging")
     @Operation(summary = "제목으로 다이어리 리스트 페이징 조회 API", description = "제목으로 다이어리 리스트를 페이징으로 조회합니다. Param으로 제목을 입력하세요.", security = @SecurityRequirement(name = "accessToken"))
-    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByTitle(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size) {
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByTitle(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(9) Integer size) {
         Page<Post> posts = postQueryService.getPostsByTitle(Optional.of(search.orElse("")), page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostPreviewListDTO(posts));
     }
@@ -169,7 +169,7 @@ public class PostController {
     // 카테고리명으로 다이어리 리스트 페이징 조회
     @GetMapping("/categories/paging")
     @Operation(summary = "카테고리명으로 다이어리 리스트 페이징 조회 API", description = "카테고리명으로 다이어리 리스트를 페이징 조회합니다. 입력한 카테고리가 포함된 모든 다이어리를 조회할 수 있습니다. Param으로 카테고리를 입력하세요.", security = @SecurityRequirement(name = "accessToken"))
-    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByCategoryName(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByCategoryName(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(9) Integer size){
         Page<Post> posts = postQueryService.getPostsByCategories(Optional.of(search.orElse("")), page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostPreviewListDTO(posts));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #129

## 📝작업 내용
> 프로젝트별 저자의 다이어리 페이징 조회, 팀별 저자의 다이어리 페이징 조회 기능에서도 공동저자로 설정된 다이어리도 함께 조회되도록 수정
> 프로젝트별 저자의 다이어리는 페이지별 5개씩, 팀별 저자의 다이어리는 페이지별 9개씩 조회되도록 수정
> 제목과 카테고리명으로 다이어리 검색은 페이지별 9개씩 조회되도록 수정

## 🔎코드 설명 및 참고 사항
> 프로젝트별 저자의 다이어리 페이징 조회, 팀별 저자의 다이어리 페이징 조회 기능에서도 공동저자로 설정된 다이어리도 함께 조회되도록 수정

## 💬리뷰 요구사항
>
