### PR TITLE
Refactor: 인기글, 최신글, 팔로잉글 조회시 postImageUrl 리스트도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -466,16 +466,30 @@ public class PostConverter {
 
     // 메인페이지 인기글 전체 리스트 조회
     public static PostResponseDTO.PostPopularDTO toPostPopularDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostPopularDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .fileUrl((post.getThumbnailImage() != null)
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
                         ? post.getThumbnailImage().getFileUrl()
                         : "")
-                .postTitle(post.getPostTitle())
-                .nickname(post.getMember().getNickname())
-                .postBody(post.getPostBody())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
@@ -495,16 +509,30 @@ public class PostConverter {
 
     // 메인페이지 인기글 멤버 관심 카테고리별 리스트 조회
     public static PostResponseDTO.PostPopularMemberCategoryDTO toPostPopularMemberCategoryDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostPopularMemberCategoryDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .fileUrl((post.getThumbnailImage() != null)
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
                         ? post.getThumbnailImage().getFileUrl()
                         : "")
-                .postTitle(post.getPostTitle())
-                .nickname(post.getMember().getNickname())
-                .postBody(post.getPostBody())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
@@ -524,16 +552,30 @@ public class PostConverter {
 
     // 메인페이지 최신글 리스트 조회
     public static PostResponseDTO.PostLatestDTO toPostLatestDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostLatestDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .fileUrl((post.getThumbnailImage() != null)
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
                         ? post.getThumbnailImage().getFileUrl()
                         : "")
-                .postTitle(post.getPostTitle())
-                .nickname(post.getMember().getNickname())
-                .postBody(post.getPostBody())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
@@ -553,16 +595,30 @@ public class PostConverter {
 
     // 메인페이지 팔로잉 게시글 리스트 조회
     public static PostResponseDTO.PostFollowingDTO toPostFollowingDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostFollowingDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .fileUrl((post.getThumbnailImage() != null)
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
                         ? post.getThumbnailImage().getFileUrl()
                         : "")
-                .postTitle(post.getPostTitle())
-                .nickname(post.getMember().getNickname())
-                .postBody(post.getPostBody())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
@@ -582,16 +638,30 @@ public class PostConverter {
 
     // 제목 & 본문 & 저자 & 프로젝트 & 카테고리 검색
     public static PostResponseDTO.PostSearchTitleDTO toPostSearchTitleDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Categories::getName)
+                .collect(Collectors.toList());
+
         return PostResponseDTO.PostSearchTitleDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .fileUrl((post.getThumbnailImage() != null)
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
                         ? post.getThumbnailImage().getFileUrl()
                         : "")
-                .postTitle(post.getPostTitle())
-                .nickname(post.getMember().getNickname())
-                .postBody(post.getPostBody())
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
                 .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/global/web/dto/Post/PostResponseDTO.java
@@ -379,11 +379,19 @@ public class PostResponseDTO {
     public static class PostPopularDTO {
         Long postId;
         Long memberId;
-        String fileUrl;
-        String postTitle;
         String nickname;
+        Long teamId;
+        Long projectId;
+        String postTitle;
         String postBody;
+        String thumbnailImageUrl;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
     // 메인페이지 인기글 멤버 관심 카테고리별 리스트 조회
@@ -407,11 +415,19 @@ public class PostResponseDTO {
     public static class PostPopularMemberCategoryDTO {
         Long postId;
         Long memberId;
-        String fileUrl;
-        String postTitle;
         String nickname;
+        Long teamId;
+        Long projectId;
+        String postTitle;
         String postBody;
+        String thumbnailImageUrl;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
     // 메인페이지 최신글 리스트 조회
@@ -435,11 +451,19 @@ public class PostResponseDTO {
     public static class PostLatestDTO {
         Long postId;
         Long memberId;
-        String fileUrl;
-        String postTitle;
         String nickname;
+        Long teamId;
+        Long projectId;
+        String postTitle;
         String postBody;
+        String thumbnailImageUrl;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
     // 메인페이지 팔로잉 게시글 리스트 조회
@@ -463,11 +487,19 @@ public class PostResponseDTO {
     public static class PostFollowingDTO {
         Long postId;
         Long memberId;
-        String fileUrl;
-        String postTitle;
         String nickname;
+        Long teamId;
+        Long projectId;
+        String postTitle;
         String postBody;
+        String thumbnailImageUrl;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
     // 제목 & 본문 & 저자 & 프로젝트 & 카테고리 검색
@@ -491,11 +523,19 @@ public class PostResponseDTO {
     public static class PostSearchTitleDTO {
         Long postId;
         Long memberId;
-        String fileUrl;
-        String postTitle;
         String nickname;
+        Long teamId;
+        Long projectId;
+        String postTitle;
         String postBody;
+        String thumbnailImageUrl;
+        Boolean postStatus;
+        String postCategory;
+        Set<Long> coauthorIds;
+        PostAccess postAccess;
+        PostFileResponseDTO.PostFileListDTO postFileList;
         LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #199

## 📝작업 내용
> 인기글, 최신글, 팔로잉글 조회시 postImageUrl 리스트도 함께 반환하도록 수정

## 🔎코드 설명 및 참고 사항
> 인기글, 최신글, 팔로잉글 조회시 postImageUrl 리스트도 함께 반환하도록 수정

## 💬리뷰 요구사항
>
