### PR TITLE
Refactor: 인접한 다이어리 조회시 닉네임 반환 오류 발생으로 반환 안하도록 재수정

### DIFF
--- a/src/main/java/com/codiary/backend/global/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/global/converter/PostConverter.java
@@ -354,7 +354,7 @@ public class PostConverter {
         return PostResponseDTO.PostAdjacentDTO.PostAdjacentPreviewDTO.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
-                .nickname(post.getMember().getNickname())
+                //.nickname(post.getMember().getNickname())
                 .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
                 .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
                 .postTitle(post.getPostTitle())


### PR DESCRIPTION
## #️⃣연관된 이슈
> #199

## 📝작업 내용
> 인접한 다이어리 조회시 닉네임 반환 오류 발생으로 반환 안하도록 재수정

## 🔎코드 설명 및 참고 사항
> 인접한 다이어리 조회시 닉네임 반환 오류 발생으로 반환 안하도록 재수정

## 💬리뷰 요구사항
>
