### PR TITLE
Feat: 마이페이지 정보 조회 API 개발

### DIFF
--- a/src/main/java/com/codiary/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codiary/backend/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.codiary.backend.domain.member.controller;
 
+import com.codiary.backend.domain.member.converter.MemberConverter;
 import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.member.service.MemberCommandService;
 import com.codiary.backend.domain.member.service.MemberQueryService;
@@ -84,5 +85,13 @@ public class MemberController {
     @Operation(summary = "사용자 프로필 사진 조회")
     public ApiResponse<MemberResponseDTO.MemberImageDTO> getProfileImage(@PathVariable Long memberId) {
         return memberQueryService.getProfileImage(memberId);
+    }
+
+    @GetMapping(path = "/profile/{member_id}")
+    @Operation(summary = "사용자 프로필 기본 정보 조회", description = "마이페이지 사용자 정보 조회 기능")
+    public ApiResponse<MemberResponseDTO.SimpleMemberDTO> getUserProfile(@PathVariable(value = "member_id") Long memberId){
+        Member member = memberCommandService.getRequester();
+        Member user = memberQueryService.getUserProfile(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, MemberConverter.toSimpleMemberResponseDto(member, user));
     }
 }

--- a/src/main/java/com/codiary/backend/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/codiary/backend/domain/member/converter/MemberConverter.java
@@ -1,0 +1,39 @@
+package com.codiary.backend.domain.member.converter;
+
+import com.codiary.backend.domain.member.dto.response.MemberResponseDTO;
+import com.codiary.backend.domain.member.entity.Member;
+import com.codiary.backend.domain.team.dto.response.TeamResponseDTO;
+import com.codiary.backend.domain.team.entity.Team;
+import com.codiary.backend.domain.techstack.entity.TechStacks;
+
+import java.util.stream.Collectors;
+
+public class MemberConverter {
+    public static MemberResponseDTO.SimpleMemberDTO toSimpleMemberResponseDto(Member member, Member user) {
+        return MemberResponseDTO.SimpleMemberDTO.builder()
+                .currentMemberId(member.getMemberId())
+                .userId(user.getMemberId())
+                .userName(user.getNickname())
+                .photoUrl((member.getImage() != null)
+                        ? member.getImage().getImageUrl()
+                        : "")
+                .githubUrl(user.getGithub())
+                .linkedinUrl(user.getLinkedin())
+                .discordUrl(user.getDiscord())
+                .introduction(user.getIntroduction())
+                .techStacksList(user.getTechStackList().stream()
+                        .map(TechStacks::getName)
+                        .collect(Collectors.toList()))
+                .teamList(user.getTeamMemberList().stream()
+                        .map(teamMember -> {
+                            Team team = teamMember.getTeam();
+                            return TeamResponseDTO.SimpleTeamDTO.builder()
+                                    .teamId(team.getTeamId())
+                                    .teamName(team.getName())
+                                    .build();
+                        })
+                        .collect(Collectors.toList()))
+                .myPage(user.getMemberId().equals(member.getMemberId()))
+                .build();
+    }
+}

--- a/src/main/java/com/codiary/backend/domain/member/dto/response/MemberResponseDTO.java
+++ b/src/main/java/com/codiary/backend/domain/member/dto/response/MemberResponseDTO.java
@@ -1,11 +1,17 @@
 package com.codiary.backend.domain.member.dto.response;
 
+import com.codiary.backend.domain.team.dto.response.TeamResponseDTO;
+import com.codiary.backend.domain.techstack.enumerate.TechStack;
 import com.codiary.backend.global.jwt.TokenInfo;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class MemberResponseDTO {
 
     @Builder
@@ -16,35 +22,19 @@ public class MemberResponseDTO {
             Long memberId) {}
 
     @Builder
-    public record BookmarkDTO(
-            Long memberId,
-            Long bookmarkId,
-            Long postId,
-            String thumbnailImageUrl,
-            String postTitle,
-            String nickname,
-            String postBody,
-            LocalDateTime createdAt) {}
-
-    // 회원별 관심 카테고리탭 리스트 조회
-    @Builder
-    public record MemberCategoryListDTO(
-            List<MemberCategoryDTO> memberCategoryList,
-            Integer listSize) {}
-
-    @Builder
-    public record MemberCategoryDTO(
-            Long memberId,
-            Long memberCategoryId,
-            Long categoryId,
-            String categoryName,
-            LocalDateTime createdAt) {}
-
-    @Builder
     public record MemberImageDTO(String url) {}
 
     @Builder
-    public record ProjectsDTO(
-            Long memberId,
-            List<String> projectList) {}
+    public record SimpleMemberDTO(
+            Long currentMemberId,
+            Long userId,
+            String userName,
+            String photoUrl,
+            String githubUrl,
+            String linkedinUrl,
+            String discordUrl,
+            String introduction,
+            List<TechStack> techStacksList,
+            List<TeamResponseDTO.SimpleTeamDTO> teamList,
+            Boolean myPage) {}
 }

--- a/src/main/java/com/codiary/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/codiary/backend/domain/member/entity/Member.java
@@ -113,4 +113,12 @@ public class Member extends BaseEntity {
   public void setImage(MemberImage image) {
     this.image = image;
   }
+
+  public void setMemberProjectMapList(List<MemberProjectMap> projects) {
+    this.memberProjectMapList = projects;
+  }
+
+  public void setTeamMemberList(List<TeamMember> teamMembers) {
+    this.teamMemberList = teamMembers;
+  }
 }

--- a/src/main/java/com/codiary/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codiary/backend/domain/member/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Boolean existsByEmail(String email);
 

--- a/src/main/java/com/codiary/backend/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/codiary/backend/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.codiary.backend.domain.member.repository;
+
+import com.codiary.backend.domain.member.entity.Member;
+
+import java.util.Optional;
+
+public interface MemberRepositoryCustom {
+    Optional<Member> findMemberWithTechStacksAndProjectsAndTeam(Long userId);
+}

--- a/src/main/java/com/codiary/backend/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/codiary/backend/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.codiary.backend.domain.member.repository;
+
+import com.codiary.backend.domain.member.entity.Member;
+import com.codiary.backend.domain.member.entity.MemberProjectMap;
+import com.codiary.backend.domain.member.entity.QMemberProjectMap;
+import com.codiary.backend.domain.project.entity.QProject;
+import com.codiary.backend.domain.team.entity.QTeam;
+import com.codiary.backend.domain.team.entity.QTeamMember;
+import com.codiary.backend.domain.team.entity.TeamMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.codiary.backend.domain.member.entity.QMember.member;
+import static com.codiary.backend.domain.techstack.entity.QTechStacks.techStacks;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<Member> findMemberWithTechStacksAndProjectsAndTeam(Long userId) {
+        Member fetchedMember = queryFactory
+                .selectFrom(member)
+                .leftJoin(member.techStackList, techStacks).fetchJoin()
+                .where(member.memberId.eq(userId))
+                .fetchOne();
+
+        fetchMemberProjects(userId, fetchedMember);
+
+        fetchTeamMembers(userId, fetchedMember);
+
+        return Optional.ofNullable(fetchedMember);
+    }
+
+    private void fetchMemberProjects(Long userId, Member fetchedMember) {
+        List<MemberProjectMap> projects = queryFactory
+                .selectFrom(QMemberProjectMap.memberProjectMap)
+                .leftJoin(QMemberProjectMap.memberProjectMap.project, QProject.project)
+                .where(QMemberProjectMap.memberProjectMap.member.memberId.eq(userId))
+                .fetch();
+
+        fetchedMember.setMemberProjectMapList(projects);
+    }
+
+    private void fetchTeamMembers(Long userId, Member fetchedMember) {
+        List<TeamMember> teamMembers = queryFactory
+                .selectFrom(QTeamMember.teamMember)
+                .leftJoin(QTeamMember.teamMember.team, QTeam.team)
+                .where(QTeamMember.teamMember.member.memberId.eq(userId))
+                .fetch();
+
+        fetchedMember.setTeamMemberList(teamMembers);
+    }
+}

--- a/src/main/java/com/codiary/backend/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codiary/backend/domain/member/service/MemberQueryService.java
@@ -4,6 +4,7 @@ import com.codiary.backend.domain.member.repository.MemberRepository;
 import com.codiary.backend.global.apiPayload.ApiResponse;
 import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
 import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
+import com.codiary.backend.global.apiPayload.exception.GeneralException;
 import com.codiary.backend.global.apiPayload.exception.handler.MemberHandler;
 import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.member.dto.response.MemberResponseDTO;
@@ -21,5 +22,11 @@ public class MemberQueryService{
         String url = (user.getImage() != null) ? user.getImage().getImageUrl() : "";
         MemberResponseDTO.MemberImageDTO response = new MemberResponseDTO.MemberImageDTO(url);
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, response);
+    }
+
+    public Member getUserProfile(Long memberId) {
+        Member user = memberRepository.findMemberWithTechStacksAndProjectsAndTeam(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        return user;
     }
 }

--- a/src/main/java/com/codiary/backend/domain/team/dto/response/TeamResponseDTO.java
+++ b/src/main/java/com/codiary/backend/domain/team/dto/response/TeamResponseDTO.java
@@ -1,0 +1,16 @@
+package com.codiary.backend.domain.team.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TeamResponseDTO {
+
+    @Builder
+    public record SimpleTeamDTO(
+            Long teamId,
+            String teamName) {}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #227 

## 📝작업 내용
- 마이페이지에서 사용자 정보 조회하는 API 개발하였습니다.

## 🔎코드 설명 및 참고 사항
- member 조회 시 techStacks, Projects, Team 정보가 필요하므로 multipleBag 예외를 방지하기 위해 querydsl을 이용해 쿼리를 나눠 작성하였습니다.
- response는 모두 snake 형식으로 반환되도록 설정했습니다. - yml에 설정

## 💬리뷰 요구사항
>
