### PR TITLE
Feat: Full-text Search를 이용한 다이어리 검색 결과 페이지네이션

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Make application-secret.yml
         run: |
           cd ./src/main
-          mkdir resources
+          [ ! -d "resources" ] && mkdir resources
           cd ./resources
           touch ./application.yml
           echo "${{ secrets.APPLICATION_SECRET_YML}}" > ./application.yml

--- a/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
@@ -1,0 +1,36 @@
+package com.codiary.backend.domain.post.controller;
+
+import com.codiary.backend.domain.post.converter.PostConverter;
+import com.codiary.backend.domain.post.dto.response.PostResponseDTO;
+import com.codiary.backend.domain.post.entity.Post;
+import com.codiary.backend.domain.post.service.PostService;
+import com.codiary.backend.global.apiPayload.ApiResponse;
+import com.codiary.backend.global.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/post")
+@Tag(name = "게시글 API", description = "게시글 관련 API입니다.")
+public class PostController {
+    private final PostService postService;
+
+    @Operation(summary = "게시글 검색 결과 페이지네이션", description = "게시글(제목/내용) 키워드 검색 결과를 페이지네이션하여 반환합니다.")
+    @GetMapping("/search")
+    public ApiResponse<Page<PostResponseDTO.SimplePostResponseDTO>> searchPost(
+            @RequestParam(value = "keyword", defaultValue = "", required = false) String keyword,
+            @PageableDefault(size = 9) Pageable pageable) {
+        Page<Post> postPage = postService.searchPost(keyword, pageable);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostListResponseDto(postPage));
+    }
+
+}

--- a/src/main/java/com/codiary/backend/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/domain/post/converter/PostConverter.java
@@ -1,0 +1,22 @@
+package com.codiary.backend.domain.post.converter;
+
+import com.codiary.backend.domain.post.dto.response.PostResponseDTO;
+import com.codiary.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+
+public class PostConverter {
+    public static Page<PostResponseDTO.SimplePostResponseDTO> toPostListResponseDto(Page<Post> postList) {
+        return postList.map(PostConverter::toSimplePostResponseDto);
+    }
+
+    private static PostResponseDTO.SimplePostResponseDTO toSimplePostResponseDto(Post post) {
+        return PostResponseDTO.SimplePostResponseDTO.builder()
+                .id(post.getPostId())
+                .title(post.getPostTitle())
+                .body(post.getPostBody())
+                .author(post.getMember() != null ? post.getMember().getNickname() : null)
+                .createdAt(post.getCreatedAt())
+                .thumbnailImage(post.getThumbnailImage() != null ? post.getThumbnailImage().getFileUrl() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/codiary/backend/domain/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/domain/post/dto/response/PostResponseDTO.java
@@ -1,0 +1,24 @@
+package com.codiary.backend.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class PostResponseDTO {
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SimplePostResponseDTO(
+            Long id,
+            String title,
+            String body,
+            String author,
+            LocalDateTime createdAt,
+            String thumbnailImage
+    ) {
+    }
+}

--- a/src/main/java/com/codiary/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.codiary.backend.domain.post.repository;
+
+import com.codiary.backend.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+}

--- a/src/main/java/com/codiary/backend/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/codiary/backend/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.codiary.backend.domain.post.repository;
+
+import com.codiary.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+    Page<Post> searchPost(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/codiary/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/codiary/backend/domain/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.codiary.backend.domain.post.repository;
+
+import com.codiary.backend.domain.post.entity.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.codiary.backend.domain.post.entity.QPost.post;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<Post> searchPost(String keyword, Pageable pageable) {
+        List<Post> postList = queryFactory
+                .selectDistinct(post)
+                .from(post)
+                .where(keywordEq(keyword)) // Full-Text Search 조건
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(post.count())
+                .from(post)
+                .where(keywordEq(keyword))  // Full-Text Search 조건
+                .fetchOne();
+
+        return new PageImpl<>(postList, pageable, total);
+    }
+
+    private BooleanExpression keywordEq(String keyword) {
+        if(keyword == null || keyword.isEmpty()) {
+            return null;
+        }
+        NumberExpression<Double> numberTemplate = Expressions.numberTemplate(Double.class,"function('match', {0}, {1}, {2})", post.postTitle, post.postBody, keyword);
+
+        return numberTemplate.gt(0);
+    }
+}

--- a/src/main/java/com/codiary/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostService.java
@@ -1,0 +1,19 @@
+package com.codiary.backend.domain.post.service;
+
+import com.codiary.backend.domain.post.entity.Post;
+import com.codiary.backend.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+
+    public Page<Post> searchPost(String keyword, Pageable pageable) {
+        //business logic & return
+        return postRepository.searchPost(keyword, pageable);
+    }
+}

--- a/src/main/java/com/codiary/backend/global/config/CustomFunctionContributor.java
+++ b/src/main/java/com/codiary/backend/global/config/CustomFunctionContributor.java
@@ -1,0 +1,19 @@
+package com.codiary.backend.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.StandardBasicTypes;
+
+public class CustomFunctionContributor implements FunctionContributor {
+
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        BasicType<Double> resultType = functionContributions
+                .getTypeConfiguration()
+                .getBasicTypeRegistry()
+                .resolve(StandardBasicTypes.DOUBLE);
+
+        functionContributions.getFunctionRegistry()
+                .registerPattern("match", "match(?1,?2) against (?3 in natural language mode)", resultType);
+    }
+}

--- a/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/codiary/backend/global/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v2/members/sign-up", "/api/v2/members/sign-up/check-email", "api/v2/members/sign-up/check-nickname").permitAll()
                                 .requestMatchers("/api/v2/members/login", "/api/v2/members/refresh", "api/v2/members/logout").permitAll()
                                 // Post 관련 접근
+                                .requestMatchers("/api/v2/post/search").permitAll()
                                 // Comment 관련 접근
                                 // Team 관련 접근
                                 // Bookmark 관련 접근

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.codiary.backend.global.config.CustomFunctionContributor


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
- #246

## 📝작업 내용
다이어리 검색(제목/내용) 결과 페이지네이션구현

## 🔎코드 설명 및 참고 사항
성능 개선을 위해 기존의 LIKE절을 이용한 검색이 아닌 Full-text search 검색으로 구현했습니다!
> 1. Querydsl은 MATCH(...) AGAINST(...)를 지원하지 않는다.
> 2. MATCH(...) AGAINST(...)는 Boolean이 아닌, Double을 반환한다.
> 3. Hibernate의 SQLFunctionTemplate은 더 이상 사용할 수 없다.(deprecated)

세가지 이유로 CustomFunctionContributor 만들었으니 참고부탁드립니다 :)

## 💬리뷰 요구사항
>
