### PR TITLE
Feat: 게시글 조회 관련 API 기능 개발

### DIFF
--- a/src/main/java/com/codiary/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/codiary/backend/domain/category/service/CategoryService.java
@@ -6,6 +6,7 @@ import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.member.entity.MemberCategory;
 import com.codiary.backend.domain.member.repository.MemberCategoryRepository;
 import com.codiary.backend.domain.member.repository.MemberRepository;
+import com.codiary.backend.domain.post.entity.Post;
 import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
 import com.codiary.backend.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -71,5 +72,14 @@ public class CategoryService {
         memberCategory.getMember().getMemberCategoryList().remove(memberCategory);
         memberCategory.getCategory().getMemberCategoryList().remove(memberCategory);
         memberCategoryRepository.delete(memberCategory);
+    }
+
+
+    @Transactional
+    public Category addCategory(Post post, String categoryName) {
+        return categoryRepository.findByName(categoryName)
+                .orElseGet(() -> categoryRepository.save(Category.builder()
+                        .name(categoryName)
+                        .build()));
     }
 }

--- a/src/main/java/com/codiary/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codiary/backend/domain/member/controller/AuthController.java
@@ -26,14 +26,14 @@ public class AuthController {
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, response);
     }
 
-    @GetMapping("sign_up/emails/check")
+    @GetMapping("sign_up/email/check")
     @Operation(summary = "이메일 중복 확인")
     public ApiResponse<String> checkEmailDuplication(@Valid @RequestParam String email) {
         String response = authService.checkEmailDuplication(email);
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, response);
     }
 
-    @GetMapping("sign_up/nicknames/check")
+    @GetMapping("sign_up/nickname/check")
     @Operation(summary = "닉네임 중복 확인")
     public ApiResponse<String> checkNicknameDuplication(@Valid @RequestParam String nickname) {
         String response = authService.checkNicknameDuplication(nickname);

--- a/src/main/java/com/codiary/backend/domain/member/controller/FollowController.java
+++ b/src/main/java/com/codiary/backend/domain/member/controller/FollowController.java
@@ -51,7 +51,7 @@ public class FollowController {
     }
 
     @Operation(summary = "유저를 팔로우한 팔로워 목록 조회", description = "로그인한 유저를 팔로우한 팔로워 목록 조회")
-    @GetMapping("/followers")
+    @GetMapping("/follower")
     public ApiResponse<List<MemberResponseDTO.SimpleMemberDTO>> getFollowers() {
         Member member = memberCommandService.getRequester();
         List<Member> followers = followService.getFollowers(member);

--- a/src/main/java/com/codiary/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codiary/backend/domain/member/controller/MemberController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v2/members")
+@RequestMapping("/api/v2/member")
 @Tag(name = "회원 API", description = "회원정보 조회/수정/삭제 관련 API입니다.")
 public class MemberController {
 

--- a/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
@@ -26,6 +26,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Pageable;
 import com.codiary.backend.global.jwt.JwtTokenProvider;
 
+import java.util.Optional;
+import java.util.Set;
+
 
 @RequiredArgsConstructor
 @Validated
@@ -55,7 +58,7 @@ public class PostController {
 
     // 멤버의 게시글 수정하기
     @PatchMapping(path = "/{postId}", consumes = "multipart/form-data")
-    @Operation(summary = "다이어리 수정 API", description = "다이어리를 수정합니다.")
+    @Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다.")
     public ApiResponse<PostResponseDTO.UpdatePostResultDTO> updatePost(@ModelAttribute PostRequestDTO.UpdatePostDTO request, @PathVariable Long postId){
         Member member = memberCommandService.getRequester();
         jwtTokenProvider.isValidToken(member.getMemberId());
@@ -66,7 +69,7 @@ public class PostController {
 
     // 게시글 삭제하기
     @DeleteMapping("/{postId}")
-    @Operation(summary = "다이어리 삭제 API", description = "다이어리를 삭제합니다.")
+    @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
     public ApiResponse<?> deletePost(@PathVariable Long postId){
         Member member = memberCommandService.getRequester();
         jwtTokenProvider.isValidToken(member.getMemberId());
@@ -75,56 +78,78 @@ public class PostController {
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, null);
     }
 
-    // 저자의 다이어리 리스트 페이징 조회
+    // 저자의 게시글 리스트 페이징 조회
     @GetMapping("/member/{memberId}/paging")
-    @Operation(summary = "저자의 다이어리 리스트 페이징 조회 API", description = "저자의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
+    @Operation(summary = "저자의 게시글 리스트 페이징 조회 API", description = "저자의 게시글 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
     public ApiResponse<PostResponseDTO.MemberPostPreviewListDTO> findPostByMember(@PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size) {
         Page<Post> posts = postQueryService.getPostsByMember(memberId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostPreviewListDTO(posts));
     }
 
 
-    // 팀의 다이어리 리스트 페이징 조회
+    // 팀의 게시글 리스트 페이징 조회
     @GetMapping("/team/{teamId}/paging")
-    @Operation(summary = "팀의 다이어리 리스트 페이징 조회 API", description = "팀의 다이어리 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
+    @Operation(summary = "팀의 게시글 리스트 페이징 조회 API", description = "팀의 게시글 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
     public ApiResponse<PostResponseDTO.TeamPostPreviewListDTO> findPostByTeam(@PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(6) Integer size){
         Page<Post> posts = postQueryService.getPostsByTeam(teamId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toTeamPostPreviewListDTO(posts));
     }
 
 
-    // 프로젝트별 저자의 다이어리 리스트 페이징 조회
+    // 프로젝트별 저자의 게시글 리스트 페이징 조회
+    @GetMapping("/project/{projectId}/member/{memberId}/paging")
+    @Operation(summary = "프로젝트별 저자의 게시글 리스트 페이징 조회 API", description = "프로젝트별 저자의 게시글 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
+    public ApiResponse<PostResponseDTO.MemberPostInProjectPreviewListDTO> findPostByMemberInProject(@PathVariable Long projectId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(5) Integer size){
+        Page<Post> posts = postQueryService.getPostsByMemberInProject(projectId, memberId, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostInProjectPreviewListDTO(posts));
+    }
 
 
-
-    // 프로젝트별 팀의 다이어리 리스트 페이징 조회
-
-
-
-    // 팀별 저자의 다이러리 리스트 페이징 조회
-
-
-
-    // 제목으로 다이어리 리스트 페이징 조회
+    // 프로젝트별 팀의 게시글 리스트 페이징 조회
+    @GetMapping("/project/{projectId}/team/{teamId}/paging")
+    @Operation(summary = "프로젝트별 팀의 게시글 리스트 페이징 조회 API", description = "프로젝트별 팀의 게시글 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 프로젝트의 'projectId'와 팀의 'teamId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
+    public ApiResponse<PostResponseDTO.TeamPostInProjectPreviewListDTO> findPostByTeamInProject(@PathVariable Long projectId, @PathVariable Long teamId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(6) Integer size){
+        Page<Post> posts = postQueryService.getPostsByTeamInProject(projectId, teamId, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toTeamPostInProjectPreviewListDTO(posts));
+    }
 
 
-
-    // 카테고리명으로 다이어리 리스트 페이징 조회
-
-
-
-    // 인접한 다이어리 조회 (이전 다이어리, 다음 다이어리)
-
-
-
+    // 팀별 저자의 게시글 리스트 페이징 조회
+    @GetMapping("/team/{teamId}/member/{memberId}/paging")
+    @Operation(summary = "팀별 저자의 게시글 리스트 페이징 조회 API", description = "팀별 저자의 게시글 리스트를 페이징으로 조회하기 위해 'Path Variable'로 해당 팀의 'teamId'와 저자의 'memberId'를 받습니다. **첫 페이지는 0부터 입니다.**", security = @SecurityRequirement(name = "accessToken"))
+    public ApiResponse<PostResponseDTO.MemberPostInTeamPreviewListDTO> findPostByMemberInTeam(@PathVariable Long teamId, @PathVariable Long memberId, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(6) Integer size){
+        Page<Post> posts = postQueryService.getPostsByMemberInTeam(teamId, memberId, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toMemberPostInTeamPreviewListDTO(posts));
+    }
 
 
+    // 제목으로 게시글 리스트 페이징 조회
+    @GetMapping("/title/paging")
+    @Operation(summary = "제목으로 게시글 리스트 페이징 조회 API", description = "제목으로 게시글 리스트를 페이징으로 조회합니다. Param으로 제목을 입력하세요.", security = @SecurityRequirement(name = "accessToken"))
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByTitle(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(9) Integer size) {
+        Page<Post> posts = postQueryService.getPostsByTitle(Optional.of(search.orElse("")), page, size);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostPreviewListDTO(posts));
+    }
 
 
+//    // 카테고리명으로 게시글 리스트 페이징 조회
+//    @GetMapping("/categories/paging")
+//    @Operation(summary = "카테고리명으로 게시글 리스트 페이징 조회 API", description = "카테고리명으로 게시글 리스트를 페이징 조회합니다. 입력한 카테고리가 포함된 모든 다이어리를 조회할 수 있습니다. Param으로 카테고리를 입력하세요.", security = @SecurityRequirement(name = "accessToken"))
+//    public ApiResponse<PostResponseDTO.PostPreviewListDTO> findPostsByCategoryName(@RequestParam Optional<String> search, @RequestParam @Min(0) Integer page, @RequestParam @Min(1) @Max(9) Integer size){
+//        Page<Post> posts = postQueryService.getPostsByCategories(Optional.of(search.orElse("")), page, size);
+//        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostPreviewListDTO(posts));
+//    }
 
 
+    // 인접한 게시글 조회 (이전 게시글, 다음 게시글)
+    @GetMapping("/{postId}/adjacent")
+    @Operation(summary = "인접한 게시글 조회 API", description = "특정 게시글의 인접한 게시글을 조회합니다.", security = @SecurityRequirement(name = "accessToken"))
+    public ApiResponse<PostResponseDTO.PostAdjacentDTO> findAdjacentPosts(@PathVariable Long postId){
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostAdjacentDTO(postQueryService.findAdjacentPosts(postId)));
+    }
 
 
+    // 게시글 검색 결과 페이지네이션
     @Operation(summary = "게시글 검색 결과 페이지네이션", description = "게시글(제목/내용) 키워드 검색 결과를 페이지네이션하여 반환합니다.")
     @GetMapping("/search")
     public ApiResponse<Page<PostResponseDTO.SimplePostResponseDTO>> searchPost(
@@ -134,4 +159,15 @@ public class PostController {
         return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toPostListResponseDto(postPage));
     }
 
+
+    // 게시글의 카테고리 설정 및 변경
+    @PatchMapping("/category/{postId}")
+    @Operation(summary = "게시글의 카테고리 설정 및 변경 API", description = "게시글의 카테고리를 설정 및 변경합니다.")
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCategory(@PathVariable Long postId, @RequestBody Set<String> categoryNames){
+        Member member = memberCommandService.getRequester();
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Post updatedPost = postCommandService.setPostCategories(postId, categoryNames);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toSetPostCategoriesResultDTO(updatedPost));
+    }
 }

--- a/src/main/java/com/codiary/backend/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/codiary/backend/domain/post/converter/PostConverter.java
@@ -94,6 +94,51 @@ public class PostConverter {
                 .build();
     }
 
+    // Post 조회
+    public static PostResponseDTO.PostPreviewDTO toPostPreviewDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.PostPreviewDTO.builder()
+                .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // Post 전체 리스트 조회
+    public static PostResponseDTO.PostPreviewListDTO toPostPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.PostPreviewDTO> postPreviewDTOList = posts.getContent().stream()
+                .map(PostConverter::toPostPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.PostPreviewListDTO.builder()
+                .posts(postPreviewDTOList)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+
 
     // 저자별 Post 조회
     public static PostResponseDTO.MemberPostPreviewDTO toMemberPostPreviewDTO(Post post) {
@@ -183,6 +228,203 @@ public class PostConverter {
                 .build();
     }
 
+    // 프로젝트별 저자의 Post 조회
+    public static PostResponseDTO.MemberPostInProjectPreviewDTO toMemberPostInProjectPreviewDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInProjectPreviewDTO.builder()
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .memberId(post.getMember().getMemberId())
+                .postId(post.getPostId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 프로젝트별 저자의 Post 페이징 조회
+    public static PostResponseDTO.MemberPostInProjectPreviewListDTO toMemberPostInProjectPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.MemberPostInProjectPreviewDTO> memberPostInProjectPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toMemberPostInProjectPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInProjectPreviewListDTO.builder()
+                .posts(memberPostInProjectPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+    // 프로젝트별 팀의 Post 조회
+    public static PostResponseDTO.TeamPostInProjectPreviewDTO toTeamPostInProjectPreviewDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.TeamPostInProjectPreviewDTO.builder()
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .memberId(post.getMember().getMemberId())
+                .postId(post.getPostId())
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 프로젝트별 팀의 Post 페이징 조회
+    public static PostResponseDTO.TeamPostInProjectPreviewListDTO toTeamPostInProjectPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.TeamPostInProjectPreviewDTO> teamPostInProjectPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toTeamPostInProjectPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.TeamPostInProjectPreviewListDTO.builder()
+                .posts(teamPostInProjectPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+    // 팀별 멤버의 Post 조회
+    public static PostResponseDTO.MemberPostInTeamPreviewDTO toMemberPostInTeamPreviewDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInTeamPreviewDTO.builder()
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .memberId(post.getMember().getMemberId())
+                .postId(post.getPostId())
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    // 팀별 멤버의 Post 페이징 조회
+    public static PostResponseDTO.MemberPostInTeamPreviewListDTO toMemberPostInTeamPreviewListDTO(Page<Post> posts) {
+        List<PostResponseDTO.MemberPostInTeamPreviewDTO> memberPostInTeamPreviewListDTO = posts.getContent().stream()
+                .map(PostConverter::toMemberPostInTeamPreviewDTO)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.MemberPostInTeamPreviewListDTO.builder()
+                .posts(memberPostInTeamPreviewListDTO)
+                .listSize(posts.getNumberOfElements())
+                .totalPage(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .isFirst(posts.isFirst())
+                .isLast(posts.isLast())
+                .build();
+    }
+
+    // 특정 Post의 인접한 Post 조회 (이전, 다음 Post 조회)
+    public static PostResponseDTO.PostAdjacentDTO.PostAdjacentPreviewDTO toPostAdjacentPreviewDTO(Post post) {
+        if (post == null) return null;
+
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.PostAdjacentDTO.PostAdjacentPreviewDTO.builder()
+                .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .nickname(post.getMember().getNickname())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    public static PostResponseDTO.PostAdjacentDTO toPostAdjacentDTO(Post.PostAdjacent adjacent) {
+        return PostResponseDTO.PostAdjacentDTO.builder()
+                .hadOlder(adjacent.getOlderPost() != null)
+                .hasLater(adjacent.getLaterPost() != null)
+                .olderPost(toPostAdjacentPreviewDTO(adjacent.getOlderPost()))
+                .laterPost(toPostAdjacentPreviewDTO(adjacent.getLaterPost()))
+                .build();
+    }
+
+
+    public static PostResponseDTO.UpdatePostResultDTO toSetPostCategoriesResultDTO(Post post) {
+        List<String> postCategories = post.getCategoriesList().stream()
+                .map(Category::getName)
+                .collect(Collectors.toList());
+
+        return PostResponseDTO.UpdatePostResultDTO.builder()
+                .postId(post.getPostId())
+                .memberId(post.getMember().getMemberId())
+                .teamId(post.getTeam() != null ? post.getTeam().getTeamId() : null)
+                .projectId(post.getProject() != null ? post.getProject().getProjectId() : null)
+                .postTitle(post.getPostTitle())
+                .postBody(post.getPostBody())
+                .postStatus(post.getPostStatus())
+                .postCategory(String.join(", ", postCategories))
+                .coauthorIds(post.getAuthorsList().stream()
+                        .map(author -> author.getMember().getMemberId())
+                        .collect(Collectors.toSet()))
+                .postAccess(post.getPostAccess())
+                .thumbnailImageUrl((post.getThumbnailImage() != null)
+                        ? post.getThumbnailImage().getFileUrl()
+                        : "")
+                .postFileList(PostFileConverter.toPostFileListDTO(post.getPostFileList()))
+                .build();
+    }
 
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/com/codiary/backend/domain/post/dto/response/PostResponseDTO.java
@@ -67,6 +67,41 @@ public class PostResponseDTO {
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record PostPreviewDTO ( // Post 조회
+        Long postId,
+        Long memberId,
+        Long teamId,
+        Long projectId,
+        String postTitle,
+        String postBody,
+        String thumbnailImageUrl,
+        Boolean postStatus,
+        String postCategory,
+        Set<Long> coauthorIds,
+        PostAccess postAccess,
+        PostFileResponseDTO.PostFileListDTO postFileList,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ){
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record PostPreviewListDTO ( // 전체 Post 리스트 조회
+        List<PostPreviewDTO> posts,
+        Integer listSize,
+        Integer totalPage,
+        Long totalElements,
+        boolean isFirst,
+        boolean isLast
+    ) {
+    }
+
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record MemberPostPreviewDTO(    // 저자별 Post 조회
             Long memberId,
             Long postId,
@@ -130,6 +165,142 @@ public class PostResponseDTO {
         boolean isFirst,
         boolean isLast
     ) {
+    }
+
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MemberPostInProjectPreviewDTO(
+            Long projectId,
+            Long memberId,
+            Long postId,
+            Long teamId,
+            String postTitle,
+            String postBody,
+            String thumbnailImageUrl,
+            Boolean postStatus,
+            String postCategory,
+            Set<Long> coauthorIds,
+            PostAccess postAccess,
+            PostFileResponseDTO.PostFileListDTO postFileList,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MemberPostInProjectPreviewListDTO ( // 프로젝트별 저자의 Post 리스트 조회
+        List<MemberPostInProjectPreviewDTO> posts,
+        Integer listSize,
+        Integer totalPage,
+        Long totalElements,
+        boolean isFirst,
+        boolean isLast
+    ){
+    }
+
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record TeamPostInProjectPreviewDTO(
+            Long projectId,
+            Long teamId,
+            Long postId,
+            Long memberId,
+            String postTitle,
+            String postBody,
+            String thumbnailImageUrl,
+            Boolean postStatus,
+            String postCategory,
+            Set<Long> coauthorIds,
+            PostAccess postAccess,
+            PostFileResponseDTO.PostFileListDTO postFileList,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record TeamPostInProjectPreviewListDTO(
+            List<TeamPostInProjectPreviewDTO> posts,
+            Integer listSize,
+            Integer totalPage,
+            Long totalElements,
+            boolean isFirst,
+            boolean isLast
+    ) {
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MemberPostInTeamPreviewDTO(
+            Long teamId,
+            Long memberId,
+            Long postId,
+            Long projectId,
+            String postTitle,
+            String postBody,
+            String thumbnailImageUrl,
+            Boolean postStatus,
+            String postCategory,
+            Set<Long> coauthorIds,
+            PostAccess postAccess,
+            PostFileResponseDTO.PostFileListDTO postFileList,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MemberPostInTeamPreviewListDTO(
+            List<MemberPostInTeamPreviewDTO> posts,
+            Integer listSize,
+            Integer totalPage,
+            Long totalElements,
+            boolean isFirst,
+            boolean isLast
+    ) {
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record PostAdjacentDTO(
+            Boolean hasLater,
+            Boolean hadOlder,
+            PostAdjacentPreviewDTO laterPost,
+            PostAdjacentPreviewDTO olderPost
+    ) {
+        @Builder
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record PostAdjacentPreviewDTO(
+                Long postId,
+                Long memberId,
+                String nickname,
+                Long teamId,
+                Long projectId,
+                String postTitle,
+                String postBody,
+                String thumbnailImageUrl,
+                Boolean postStatus,
+                String postCategory,
+                Set<Long> coauthorIds,
+                PostAccess postAccess,
+                PostFileResponseDTO.PostFileListDTO postFileList,
+                LocalDateTime createdAt,
+                LocalDateTime updatedAt
+        ) {
+        }
     }
 
 

--- a/src/main/java/com/codiary/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/codiary/backend/domain/post/entity/Post.java
@@ -99,5 +99,16 @@ public class Post extends BaseEntity {
     this.categoriesList.clear();
     this.categoriesList.addAll(categories);
   }
-  
+
+
+  @Builder
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class PostAdjacent{
+    Post laterPost;
+    Post olderPost;
+  }
+
+
 }

--- a/src/main/java/com/codiary/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/codiary/backend/domain/post/repository/PostRepository.java
@@ -2,17 +2,39 @@ package com.codiary.backend.domain.post.repository;
 
 import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.post.entity.Post;
+import com.codiary.backend.domain.project.entity.Project;
 import com.codiary.backend.domain.team.entity.Team;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    Page<Post> findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(String postTitle, Pageable pageable);
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
     Page<Post> findByMemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
     Page<Post> findByTeamOrderByCreatedAtDescPostIdDesc(Team team, Pageable pageable);
+    Page<Post> findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
     Page<Post> findByAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Member member, Pageable pageable);
+    Page<Post> findByProjectAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Project project, Member member, Pageable pageable);
+    Page<Post> findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(Project project, Team team, Pageable pageable);
+    Page<Post> findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(Team team, Member member, Pageable pageable);
+    Page<Post> findByTeamAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(Team team, Member member, Pageable pageable);
 
     boolean existsByTeam(Team team);
+    boolean existsByProject(Project project);
+    boolean existsByMember(Member member);
+
+    Optional<Post> findTopByPostIdLessThanOrderByCreatedAtDescPostIdDesc(Long postId);
+    Optional<Post> findTopByPostIdGreaterThanOrderByCreatedAtAscPostIdAsc(Long postId);
+
+    @Query("SELECT p.postId FROM Post p JOIN p.categoriesList c WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
+    List<Long> findPostIdsByCategoryName(@Param("categoryName") String categoryName);
+    Page<Post> findByPostIdIn(List<Long> postIds, Pageable pageable);
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
@@ -3,6 +3,8 @@ package com.codiary.backend.domain.post.service;
 
 
 
+import com.codiary.backend.domain.category.entity.Category;
+import com.codiary.backend.domain.category.service.CategoryService;
 import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.member.repository.MemberRepository;
 
@@ -26,7 +28,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +45,7 @@ public class PostCommandService {
     private final UuidRepository uuidRepository; // 추가
     private final PostFileRepository postFileRepository;
     private final MemberCommandService memberCommandService;
+    private final CategoryService categoryService;
     private final AmazonS3Manager s3Manager;
 
     // 포스트 생성
@@ -130,5 +136,22 @@ public class PostCommandService {
     }
 
 
+    public Post setPostCategories(Long postId, Set<String> categoryNames) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+
+        // 카테고리 이름으로 Categories 엔티티를 생성하거나 조회
+        List<Category> categories = categoryNames.stream()
+                .map(name -> {
+                    // 카테고리 이름으로 Categories 엔티티를 조회하거나 새로 생성
+                    return categoryService.addCategory(post, name);
+                })
+                .collect(Collectors.toList());
+
+        // 포스트에 카테고리를 설정
+        post.setCategories(categories);
+
+        return postRepository.save(post);
+    }
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostQueryService.java
@@ -4,27 +4,34 @@ import com.codiary.backend.domain.member.entity.Member;
 import com.codiary.backend.domain.member.repository.MemberRepository;
 import com.codiary.backend.domain.post.entity.Post;
 import com.codiary.backend.domain.post.repository.PostRepository;
+import com.codiary.backend.domain.project.entity.Project;
+import com.codiary.backend.domain.project.repository.ProjectRepository;
 import com.codiary.backend.domain.team.entity.Team;
 import com.codiary.backend.domain.team.repository.TeamRepository;
 import com.codiary.backend.global.apiPayload.code.status.ErrorStatus;
 import com.codiary.backend.global.apiPayload.exception.handler.PostHandler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class PostQueryService {
 
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final TeamRepository teamRepository;
+    private final ProjectRepository projectRepository;
 
     public Page<Post> getPostsByMember(Long memberId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
@@ -45,6 +52,29 @@ public class PostQueryService {
         return new PageImpl<>(combinedPosts.subList(start, end), request, combinedPosts.size());
     }
 
+    public Page<Post> getPostsByTitle(Optional<String> optSearch, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        if (optSearch.isPresent()) {
+            String search = optSearch.get();
+            return postRepository.findAllByPostTitleContainingIgnoreCaseOrderByCreatedAtDesc(search, request);
+        }
+        // 검색어 존재 X
+        return postRepository.findAllByOrderByCreatedAtDesc(request);
+    }
+
+    public Page<Post> getPostsByCategories(Optional<String> optSearch, int page, int size) {
+        Pageable request = PageRequest.of(page, size);
+        if (optSearch.isPresent()) {
+            String search = optSearch.get();
+            log.info("Searching posts by category with keyword: {}", search);
+            List<Long> postIds = postRepository.findPostIdsByCategoryName(search);
+            if (postIds.isEmpty()) { return Page.empty(request); }
+            return postRepository.findByPostIdIn(postIds, request);
+        }
+        return postRepository.findAllByOrderByCreatedAtDesc(request);
+    }
+
+
     public Page<Post> getPostsByTeam(Long teamId, int page, int size) {
         PageRequest request = PageRequest.of(page, size);
         Team team = teamRepository.findById(teamId).get();
@@ -52,5 +82,75 @@ public class PostQueryService {
         if (!postRepository.existsByTeam(team)){ throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM); }
         return postRepository.findByTeamOrderByCreatedAtDescPostIdDesc(team, request);
     }
+
+
+    public Page<Post> getPostsByMemberInProject(Long projectId, Long memberId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.PROJECT_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (!postRepository.existsByProject(project)) { throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_PROJECT); }
+        List<Post> postsByMember = postRepository.findByProjectAndMemberOrderByCreatedAtDescPostIdDesc(project, member, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Post> postsByCoauthor = postRepository.findByProjectAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(project, member, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        List<Post> combinedPosts = new ArrayList<>();
+        combinedPosts.addAll(postsByMember);
+        combinedPosts.addAll(postsByCoauthor);
+
+        if (combinedPosts.isEmpty()) { throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER); }
+        combinedPosts.sort(Comparator.comparing(Post::getCreatedAt).reversed());
+
+        int start = Math.min(page * size, combinedPosts.size());
+        int end = Math.min((page + 1) * size, combinedPosts.size());
+        return new PageImpl<>(combinedPosts.subList(start, end), request, combinedPosts.size());
+    }
+
+    public Page<Post> getPostsByTeamInProject(Long projectId, Long teamId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Project project = projectRepository.findById(projectId).get();
+        Team team = teamRepository.findById(teamId).get();
+
+        if (!postRepository.existsByProject(project)){ throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_PROJECT); }
+        if (!postRepository.existsByTeam(team)){ throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM); }
+        return postRepository.findByProjectAndTeamOrderByCreatedAtDescPostIdDesc(project, team, request);
+    }
+
+    public Page<Post> getPostsByMemberInTeam(Long teamId, Long memberId, int page, int size) {
+        PageRequest request = PageRequest.of(page, size);
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.TEAM_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (!postRepository.existsByTeam(team)) { throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_TEAM); }
+        if (!postRepository.existsByMember(member)) { throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER); }
+
+        List<Post> postsByMember = postRepository.findByTeamAndMemberOrderByCreatedAtDescPostIdDesc(team, member, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Post> postsByCoauthor = postRepository.findByTeamAndAuthorsList_MemberOrderByCreatedAtDescPostIdDesc(team, member, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        List<Post> combinedPosts = new ArrayList<>();
+        combinedPosts.addAll(postsByMember);
+        combinedPosts.addAll(postsByCoauthor);
+
+        if (combinedPosts.isEmpty()) { throw new PostHandler(ErrorStatus.POST_NOT_EXIST_BY_MEMBER); }
+        combinedPosts.sort(Comparator.comparing(Post::getCreatedAt).reversed());
+
+        int start = Math.min(page * size, combinedPosts.size());
+        int end = Math.min((page + 1) * size, combinedPosts.size());
+        return new PageImpl<>(combinedPosts.subList(start, end), request, combinedPosts.size());
+    }
+
+    public Post.PostAdjacent findAdjacentPosts(Long postId) {
+        return Post.PostAdjacent.builder()
+                .olderPost(postRepository.findTopByPostIdLessThanOrderByCreatedAtDescPostIdDesc(postId).orElse(null))
+                .laterPost(postRepository.findTopByPostIdGreaterThanOrderByCreatedAtAscPostIdAsc(postId).orElse(null))
+                .build();
+    }
+
+
+
+
 
 }

--- a/src/main/java/com/codiary/backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/codiary/backend/domain/team/controller/TeamController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v2/teams")
+@RequestMapping("/api/v2/team")
 @RequiredArgsConstructor
 @Tag(name = "팀 API", description = "팀 생성/조회/수정 관련 API 입니다.")
 public class TeamController {

--- a/src/main/java/com/codiary/backend/domain/team/controller/TeamFollowController.java
+++ b/src/main/java/com/codiary/backend/domain/team/controller/TeamFollowController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v2/follow/teams/{team_id}")
+@RequestMapping("/api/v2/follow/team/{team_id}")
 @Tag(name = "팀 팔로우 API", description = "팀 팔로우와 관련된 API 입니다.")
 public class TeamFollowController {
 
@@ -43,7 +43,7 @@ public class TeamFollowController {
     }
 
     @Operation(summary = "팀 팔로워 리스트 조회", description = "{team_id}에 해당하는 팀의 팔로워 리스트를 조회힙니다. 팀에 소속된 사용자만 사용 가능합니다.")
-    @GetMapping("followers")
+    @GetMapping("follower")
     public ApiResponse<TeamResponseDTO.TeamFollowersDTO> getFollowers(@PathVariable("team_id") Long teamId) {
         Member member = memberCommandService.getRequester();
         List<TeamFollow> followers = teamFollowService.getFollowers(teamId, member);


### PR DESCRIPTION
## #️⃣연관된 이슈
> 게시글 조회 관련 API 기능 개발

## 📝작업 내용
> - [x] 저자의 게시글 리스트 페이징 조회
> - [x] 팀의 게시글 리스트 페이징 조회
> - [x] 팀별 저자의 게시글 리스트 페이징 조회
> - [x] 프로젝트별 저자의 게시글 리스트 페이징 조회
> - [x] 프로젝트별 팀의 게시글 리스트 페이징 조회
> - [x] 제목으로 게시글 리스트 페이징 조회
> - [x] 인접한 게시글 조회


- 부가기능
- [x] 게시글의 카테고리 설정 및 변경 기능 

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
