### PR TITLE
Feat: 게시글 공동저자 설정 / 공개 범위 설정 / 소속 팀 설정 API 기능 구현

### DIFF
--- a/src/main/java/com/codiary/backend/domain/coauthor/entity/Author.java
+++ b/src/main/java/com/codiary/backend/domain/coauthor/entity/Author.java
@@ -45,4 +45,13 @@ public class Author {
   public void setMember(Member member) {
     this.member = member;
   }
+
+  public static Author createAuthors(Post post, Member member) {
+    Author authors = new Author();
+    authors.setPost(post);
+    authors.setMember(member);
+    return authors;
+  }
+
+
 }

--- a/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
@@ -329,4 +329,15 @@ public class PostController {
     }
 
 
+    @PatchMapping("/visibility/{postId}")
+    @Operation(summary = "게시글 공개 범위 설정 API", description = "게시글의 공개 범위를 설정합니다. (MEMBER / TEAM / ENTIRE)")
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostVisibility(@PathVariable Long postId, @RequestBody PostRequestDTO.UpdateVisibilityRequestDTO request) {
+        Member member = memberCommandService.getRequester();
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Post updatedPost = postCommandService.updateVisibility(postId, request);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost));
+    }
+
+
 }

--- a/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
@@ -305,4 +305,18 @@ public class PostController {
         return ApiResponse.onSuccess(SuccessStatus.POST_OK,
                 PostConverter.toPostListResponseDto(postQueryService.getBookmarkPost(memberDetails.getId(), pageable)));
     }
+
+    @PatchMapping("/coauthor/{postId}")
+    @Operation(summary = "게시글 공동 저자 설정 API", description = "게시글의 공동 저자를 설정합니다.")
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCoauthor(@PathVariable Long postId, @RequestBody PostRequestDTO.UpdateCoauthorRequestDTO request) {
+        Member member = memberCommandService.getRequester();
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Post updatedPost = postCommandService.updateCoauthors(postId, request);
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost));
+    }
+
+
+
+
 }

--- a/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/codiary/backend/domain/post/controller/PostController.java
@@ -306,6 +306,7 @@ public class PostController {
                 PostConverter.toPostListResponseDto(postQueryService.getBookmarkPost(memberDetails.getId(), pageable)));
     }
 
+
     @PatchMapping("/coauthor/{postId}")
     @Operation(summary = "게시글 공동 저자 설정 API", description = "게시글의 공동 저자를 설정합니다.")
     public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostCoauthor(@PathVariable Long postId, @RequestBody PostRequestDTO.UpdateCoauthorRequestDTO request) {
@@ -317,6 +318,15 @@ public class PostController {
     }
 
 
+    @PatchMapping("/team/{postId}")
+    @Operation(summary = "게시글의 소속 팀 설정 API", description = "게시글의 소속 팀을 설정합니다.")
+    public ApiResponse<PostResponseDTO.UpdatePostResultDTO> setPostTeam(@PathVariable Long postId, @RequestBody PostRequestDTO.SetTeamRequestDTO request) {
+        Member member = memberCommandService.getRequester();
+        jwtTokenProvider.isValidToken(member.getMemberId());
+
+        Post updatedPost = postCommandService.setPostTeam(postId, request.getTeamId());
+        return ApiResponse.onSuccess(SuccessStatus.POST_OK, PostConverter.toUpdatePostResultDTO(updatedPost));
+    }
 
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
+++ b/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
@@ -75,4 +75,12 @@ public class PostRequestDTO {
         private Long teamId;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateVisibilityRequestDTO {
+        private String postAccess;  // MEMBER, TEAM, ENTIRE
+    }
+
 }

--- a/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
+++ b/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
@@ -67,5 +67,12 @@ public class PostRequestDTO {
         private List<Long> memberIds;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SetTeamRequestDTO {
+        private Long teamId;
+    }
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
+++ b/src/main/java/com/codiary/backend/domain/post/dto/request/PostRequestDTO.java
@@ -59,6 +59,13 @@ public class PostRequestDTO {
         private List<MultipartFile> addedPostFiles;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateCoauthorRequestDTO {
+        private List<Long> memberIds;
+    }
 
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/codiary/backend/domain/post/entity/Post.java
@@ -93,7 +93,7 @@ public class Post extends BaseEntity {
   public void setMember(Member member) { this.member = member;}
   public void setTeam(Team team) { this.team = team;}
   public void setPostStatus(Boolean postStatus) { this.postStatus = postStatus;}
-
+  public void setPostAccess(PostAccess postAccess) { this.postAccess = postAccess;}
   public void setProject(Project project) { this.project = project;}
 
 

--- a/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
@@ -34,6 +34,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,6 +56,31 @@ public class PostCommandService {
     private final MemberCommandService memberCommandService;
     private final CategoryService categoryService;
     private final AmazonS3Manager s3Manager;
+
+
+    private void validatePostAccess(Post post, Member member) {
+        // MEMBER 접근 권한: 작성자만 접근 가능
+        if (post.getPostAccess() == PostAccess.MEMBER && !post.getMember().equals(member)) {
+            throw new GeneralException(ErrorStatus.NO_ACCESS_PERMISSION);
+        }
+        // TEAM 접근 권한: 팀 멤버만 접근 가능
+        if (post.getPostAccess() == PostAccess.TEAM && post.getTeam() != null) {
+            if (!teamRepository.isTeamMember(post.getTeam(), member)) {
+                throw new GeneralException(ErrorStatus.NO_ACCESS_PERMISSION);
+            }
+        }
+    }
+
+    private Member getAuthenticatedMember() {
+        // 현재 인증된 사용자 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // username (식별자) 가져오기
+        String username = authentication.getName();
+        // username으로 Member 엔터티 조회
+        return memberRepository.findByEmail(username)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
 
     // 포스트 생성
     public Post createPost(Long memberId, PostRequestDTO.CreatePostRequestDTO request) {
@@ -203,5 +230,27 @@ public class PostCommandService {
 
         return postRepository.save(post);
     }
+
+
+    public Post updateCoauthors(Long postId, PostRequestDTO.UpdateCoauthorRequestDTO request) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        Member authenticatedMember = getAuthenticatedMember();
+        validatePostAccess(post, authenticatedMember);
+        // 기존 공동 저자 리스트 삭제
+        post.getAuthorList().clear();
+        // 새로운 공동 저자 리스트 추가
+        Set<Author> coauthors = request.getMemberIds().stream()
+                .map(newCoauthorId -> {
+                    Member newCoauthor = memberRepository.findById(newCoauthorId).orElseThrow(() -> new IllegalArgumentException("Member not found: " + newCoauthorId));
+                    return Author.createAuthors(post, newCoauthor);
+                })
+                .collect(Collectors.toSet());
+        post.getAuthorList().addAll(coauthors);
+
+        return postRepository.save(post);
+    }
+
+
+
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
@@ -251,6 +251,19 @@ public class PostCommandService {
     }
 
 
+    public Post setPostTeam(Long postId, Long teamId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Member authenticatedMember = getAuthenticatedMember();
+        validatePostAccess(post, authenticatedMember);
+
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new GeneralException(ErrorStatus.TEAM_NOT_FOUND));
+        post.setTeam(team);
+
+        return postRepository.save(post);
+    }
+
+
 
 
 }

--- a/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/codiary/backend/domain/post/service/PostCommandService.java
@@ -264,6 +264,16 @@ public class PostCommandService {
     }
 
 
+    public Post updateVisibility(Long postId, PostRequestDTO.UpdateVisibilityRequestDTO request) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        Member authenticatedMember = getAuthenticatedMember();
+
+        if (!post.getMember().equals(authenticatedMember)) { throw new GeneralException(ErrorStatus.POST_ACCESS_SET_UNAUTHORIZED);}
+        post.setPostAccess(PostAccess.valueOf(request.getPostAccess()));
+
+        return postRepository.save(post);
+    }
+
 
 
 }

--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -59,6 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_3009", "포스트가 없습니다."),
     NO_ACCESS_PERMISSION(HttpStatus.BAD_REQUEST, "POST_3010", "전체 공개 게시글이 없습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "POST_3011", "멤버 ID 또는 팀 ID 중 하나를 입력해야 합니다."),
+    POST_COAUTHOR_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3012", "공동 저자 설정은 작성자만 가능합니다."),
 
     // 코멘트 관련 에러 4000
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT_4005", "댓글이 없습니다."),

--- a/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiary/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -60,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_ACCESS_PERMISSION(HttpStatus.BAD_REQUEST, "POST_3010", "전체 공개 게시글이 없습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "POST_3011", "멤버 ID 또는 팀 ID 중 하나를 입력해야 합니다."),
     POST_COAUTHOR_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3012", "공동 저자 설정은 작성자만 가능합니다."),
+    POST_ACCESS_SET_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "POST_3013", "가시성 설정은 작성자만 가능합니다."),
 
     // 코멘트 관련 에러 4000
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT_4005", "댓글이 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #297 

## 📝작업 내용
> - 게시글 공동 저자 설정 API 기능 구현
> - 게시글 공개 범위 설정 API 기능 구현
> - 게시글 소속 팀 설정 API 기능 구현

## 🔎코드 설명 및 참고 사항
> 멤버 및 팀의 접근 권한에 따라 설정 가능하도록 구현

## 💬리뷰 요구사항
>
